### PR TITLE
feat(bff): NestJS scaffold with global validation + error filter

### DIFF
--- a/bff/nest-cli.json
+++ b/bff/nest-cli.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/nest-cli",
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src",
+  "compilerOptions": {
+    "deleteOutDir": true
+  }
+}

--- a/bff/package.json
+++ b/bff/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "bff",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Retail shopping BFF (NestJS)",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:prod": "node dist/main",
+    "test": "jest && jest --config ./test/jest-e2e.json",
+    "test:unit": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.0",
+    "@nestjs/core": "^10.4.0",
+    "@nestjs/platform-express": "^10.4.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1",
+    "uuid": "^10.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.4.0",
+    "@nestjs/schematics": "^10.2.0",
+    "@nestjs/testing": "^10.4.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.14.0",
+    "@types/supertest": "^6.0.2",
+    "@types/uuid": "^10.0.0",
+    "jest": "^29.7.0",
+    "supertest": "^7.0.0",
+    "ts-jest": "^29.2.0",
+    "ts-loader": "^9.5.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
+    "typescript": "^5.5.4"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": ["**/*.(t|j)s"],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/bff/src/app.module.ts
+++ b/bff/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ProductsModule } from './products/products.module';
+import { DiscountsModule } from './discounts/discounts.module';
+import { CartsModule } from './carts/carts.module';
+import { CheckoutModule } from './checkout/checkout.module';
+
+@Module({
+  imports: [ProductsModule, DiscountsModule, CartsModule, CheckoutModule],
+})
+export class AppModule {}

--- a/bff/src/common/http-exception.filter.ts
+++ b/bff/src/common/http-exception.filter.ts
@@ -1,0 +1,37 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const isHttp = exception instanceof HttpException;
+    const status = isHttp ? exception.getStatus() : HttpStatus.INTERNAL_SERVER_ERROR;
+    const payload = isHttp
+      ? exception.getResponse()
+      : { message: 'Internal server error' };
+
+    if (!isHttp) {
+      this.logger.error(exception);
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      path: request.url,
+      timestamp: new Date().toISOString(),
+      ...(typeof payload === 'string' ? { message: payload } : payload),
+    });
+  }
+}

--- a/bff/src/main.ts
+++ b/bff/src/main.ts
@@ -1,0 +1,21 @@
+import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './common/http-exception.filter';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.enableCors();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.setGlobalPrefix('api');
+  const port = Number(process.env.PORT) || 3000;
+  await app.listen(port);
+}
+bootstrap();

--- a/bff/tsconfig.json
+++ b/bff/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2022",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "forceConsistentCasingInFileNames": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Sets up the NestJS BFF: package.json, tsconfig, nest-cli config
- Bootstraps on port 3000 with \`/api\` prefix, CORS, global ValidationPipe
- Adds a catch-all HttpExceptionFilter that normalises errors (statusCode/path/timestamp/message)

## Test plan
- [x] \`npm install\` in \`bff/\` succeeds
- [x] Subsequent PRs (products/discounts/carts/checkout) wire modules into AppModule

🤖 Generated with [Claude Code](https://claude.com/claude-code)