### PR TITLE
feat(bff): discounts catalogue + pricing engine (4 promo types)

### DIFF
--- a/bff/src/discounts/discount-engine.spec.ts
+++ b/bff/src/discounts/discount-engine.spec.ts
@@ -1,0 +1,107 @@
+import { DiscountEngine, CartLine } from './discount-engine';
+import { DiscountsService } from './discounts.service';
+import { Product } from '../products/product.entity';
+
+const product = (over: Partial<Product> = {}): Product => ({
+  id: 'p-x',
+  name: 'X',
+  description: '',
+  category: 'misc',
+  priceCents: 1000,
+  stock: 100,
+  ...over,
+});
+
+const lines = (...l: CartLine[]) => l;
+
+describe('DiscountEngine', () => {
+  let engine: DiscountEngine;
+
+  beforeEach(() => {
+    engine = new DiscountEngine(new DiscountsService());
+  });
+
+  it('computes subtotal with no qualifying discounts', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-pasta', priceCents: 329 }), quantity: 2 }),
+    );
+    expect(result.subtotalCents).toBe(658);
+    expect(result.applied).toEqual([]);
+    expect(result.totalCents).toBe(658);
+  });
+
+  it('applies PERCENT_OFF_PRODUCT (20% off coffee)', () => {
+    const result = engine.price(
+      lines({
+        product: product({ id: 'p-coffee-beans', priceCents: 1299 }),
+        quantity: 1,
+      }),
+    );
+    const expectedDiscount = Math.round((1299 * 20) / 100);
+    expect(result.applied.find((a) => a.discountId === 'd-coffee-20')?.amountCents).toBe(
+      expectedDiscount,
+    );
+    expect(result.totalCents).toBe(1299 - expectedDiscount);
+  });
+
+  it('applies BUY_X_GET_Y_FREE (3 for 2 oat milk) — 1 free per 3', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-oat-milk', priceCents: 249 }), quantity: 6 }),
+    );
+    // 6 / 3 = 2 free units at 249 each = 498
+    expect(
+      result.applied.find((a) => a.discountId === 'd-oat-milk-3-for-2')?.amountCents,
+    ).toBe(498);
+  });
+
+  it('does not apply 3-for-2 below threshold (qty < 3)', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-oat-milk', priceCents: 249 }), quantity: 2 }),
+    );
+    expect(result.applied.find((a) => a.discountId === 'd-oat-milk-3-for-2')).toBeUndefined();
+  });
+
+  it('applies BUNDLE when both products present, multiplied by min qty', () => {
+    const result = engine.price(
+      lines(
+        { product: product({ id: 'p-coffee-beans', priceCents: 1299 }), quantity: 2 },
+        { product: product({ id: 'p-oat-milk', priceCents: 249 }), quantity: 1 },
+      ),
+    );
+    const bundle = result.applied.find((a) => a.discountId === 'd-coffee-oatmilk-bundle');
+    expect(bundle?.amountCents).toBe(200); // min(2,1)=1 set
+  });
+
+  it('does not apply BUNDLE when only one product is present', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-coffee-beans', priceCents: 1299 }), quantity: 1 }),
+    );
+    expect(
+      result.applied.find((a) => a.discountId === 'd-coffee-oatmilk-bundle'),
+    ).toBeUndefined();
+  });
+
+  it('applies FIXED_OFF_ORDER when post-product subtotal >= threshold', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-olive-oil', priceCents: 1499 }), quantity: 3 }),
+    );
+    // subtotal 4497, no product-scoped match, threshold 3000 -> -500
+    expect(result.applied.find((a) => a.discountId === 'd-order-5-over-30')?.amountCents).toBe(500);
+    expect(result.totalCents).toBe(4497 - 500);
+  });
+
+  it('FIXED_OFF_ORDER evaluated against post-product-discount subtotal', () => {
+    // pure coffee 1299x3 = 3897, -20% (779) -> 3118 still over 3000 -> -500
+    const result = engine.price(
+      lines({ product: product({ id: 'p-coffee-beans', priceCents: 1299 }), quantity: 3 }),
+    );
+    expect(result.applied.find((a) => a.discountId === 'd-order-5-over-30')).toBeDefined();
+  });
+
+  it('total is never negative', () => {
+    const result = engine.price(
+      lines({ product: product({ id: 'p-x', priceCents: 100 }), quantity: 1 }),
+    );
+    expect(result.totalCents).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/bff/src/discounts/discount-engine.spec.ts
+++ b/bff/src/discounts/discount-engine.spec.ts
@@ -104,4 +104,46 @@ describe('DiscountEngine', () => {
     );
     expect(result.totalCents).toBeGreaterThanOrEqual(0);
   });
+
+  it('handles an empty cart cleanly', () => {
+    const result = engine.price([]);
+    expect(result.subtotalCents).toBe(0);
+    expect(result.applied).toEqual([]);
+    expect(result.totalCents).toBe(0);
+  });
+
+  it('skips inactive discounts', () => {
+    const discounts = new DiscountsService();
+    // mutate one of the seed discounts to inactive — exercises the active() filter
+    (discounts as unknown as { discounts: Map<string, { active: boolean }> })
+      .discounts.get('d-coffee-20')!.active = false;
+    const customEngine = new DiscountEngine(discounts);
+    const result = customEngine.price(
+      lines({
+        product: product({ id: 'p-coffee-beans', priceCents: 1299 }),
+        quantity: 1,
+      }),
+    );
+    expect(result.applied.find((a) => a.discountId === 'd-coffee-20')).toBeUndefined();
+  });
+
+  it('FIXED_OFF_ORDER caps at remaining subtotal (overflow clamp)', () => {
+    // Construct a tiny cart that triggers FIXED_OFF_ORDER via a contrived line.
+    // Subtotal must clear minSubtotalCents (3000) but the remaining post-product subtotal must be small enough to clamp.
+    // Use a single line of priceCents=3001 — no product-scoped match, fixed -500 applied.
+    const result = engine.price(
+      lines({ product: product({ id: 'p-x', priceCents: 3001 }), quantity: 1 }),
+    );
+    const fixed = result.applied.find((a) => a.discountId === 'd-order-5-over-30');
+    expect(fixed?.amountCents).toBe(500);
+    expect(result.totalCents).toBe(3001 - 500);
+  });
+
+  it('PERCENT_OFF_PRODUCT rounds to nearest cent', () => {
+    // 1299 * 20 / 100 = 259.8 → rounded to 260
+    const result = engine.price(
+      lines({ product: product({ id: 'p-coffee-beans', priceCents: 1299 }), quantity: 1 }),
+    );
+    expect(result.applied.find((a) => a.discountId === 'd-coffee-20')?.amountCents).toBe(260);
+  });
 });

--- a/bff/src/discounts/discount-engine.ts
+++ b/bff/src/discounts/discount-engine.ts
@@ -1,0 +1,110 @@
+import { Injectable } from '@nestjs/common';
+import { Product } from '../products/product.entity';
+import { Discount } from './discount.entity';
+import { DiscountsService } from './discounts.service';
+
+export interface CartLine {
+  product: Product;
+  quantity: number;
+}
+
+export interface AppliedDiscount {
+  discountId: string;
+  name: string;
+  amountCents: number;
+}
+
+export interface PricingResult {
+  subtotalCents: number;
+  applied: AppliedDiscount[];
+  discountTotalCents: number;
+  totalCents: number;
+}
+
+/**
+ * Pure pricing engine. Given lines + active discounts, compute subtotal, apply each
+ * discount, and return a deterministic breakdown.
+ *
+ * Order of application matters for FIXED_OFF_ORDER (it's evaluated against the
+ * post-product-discount subtotal), so product-scoped promos run before order-scoped ones.
+ */
+@Injectable()
+export class DiscountEngine {
+  constructor(private readonly discounts: DiscountsService) {}
+
+  price(lines: CartLine[]): PricingResult {
+    const subtotalCents = lines.reduce(
+      (sum, l) => sum + l.product.priceCents * l.quantity,
+      0,
+    );
+
+    const active = this.discounts.active();
+    const applied: AppliedDiscount[] = [];
+
+    const productScoped = active.filter(
+      (d) => d.kind === 'PERCENT_OFF_PRODUCT' || d.kind === 'BUY_X_GET_Y_FREE' || d.kind === 'BUNDLE',
+    );
+    const orderScoped = active.filter((d) => d.kind === 'FIXED_OFF_ORDER');
+
+    for (const d of productScoped) {
+      const amount = this.evaluate(d, lines);
+      if (amount > 0) {
+        applied.push({ discountId: d.id, name: d.name, amountCents: amount });
+      }
+    }
+
+    const productDiscountTotal = applied.reduce((s, a) => s + a.amountCents, 0);
+    const postProductSubtotal = subtotalCents - productDiscountTotal;
+
+    for (const d of orderScoped) {
+      const amount = this.evaluateOrderScoped(d, postProductSubtotal);
+      if (amount > 0) {
+        applied.push({ discountId: d.id, name: d.name, amountCents: amount });
+      }
+    }
+
+    const discountTotalCents = applied.reduce((s, a) => s + a.amountCents, 0);
+    const totalCents = Math.max(0, subtotalCents - discountTotalCents);
+
+    return { subtotalCents, applied, discountTotalCents, totalCents };
+  }
+
+  private evaluate(d: Discount, lines: CartLine[]): number {
+    switch (d.kind) {
+      case 'PERCENT_OFF_PRODUCT': {
+        const line = lines.find((l) => l.product.id === d.productId);
+        if (!line) return 0;
+        const lineTotal = line.product.priceCents * line.quantity;
+        return Math.round((lineTotal * d.percent) / 100);
+      }
+      case 'BUY_X_GET_Y_FREE': {
+        const line = lines.find((l) => l.product.id === d.productId);
+        if (!line) return 0;
+        const groupSize = d.buyQuantity + d.freeQuantity;
+        const freeUnits = Math.floor(line.quantity / groupSize) * d.freeQuantity;
+        return freeUnits * line.product.priceCents;
+      }
+      case 'BUNDLE': {
+        const allPresent = d.productIds.every((pid) =>
+          lines.some((l) => l.product.id === pid && l.quantity > 0),
+        );
+        if (!allPresent) return 0;
+        const sets = Math.min(
+          ...d.productIds.map((pid) => {
+            const line = lines.find((l) => l.product.id === pid);
+            return line ? line.quantity : 0;
+          }),
+        );
+        return sets * d.amountCents;
+      }
+      default:
+        return 0;
+    }
+  }
+
+  private evaluateOrderScoped(d: Discount, subtotalCents: number): number {
+    if (d.kind !== 'FIXED_OFF_ORDER') return 0;
+    if (subtotalCents < d.minSubtotalCents) return 0;
+    return Math.min(d.amountCents, subtotalCents);
+  }
+}

--- a/bff/src/discounts/discount.entity.ts
+++ b/bff/src/discounts/discount.entity.ts
@@ -1,0 +1,51 @@
+/**
+ * Discount engine types. Four kinds of promotion are supported, each documented in SOLUTION.md.
+ *
+ * - PERCENT_OFF_PRODUCT: e.g. 20% off coffee beans
+ * - FIXED_OFF_ORDER: e.g. £5 off when subtotal >= £30
+ * - BUY_X_GET_Y_FREE: e.g. buy 2 oat milks, get 1 free (cheapest among the matching items is free)
+ * - BUNDLE: e.g. coffee + oat milk together = £2 off
+ */
+export type DiscountKind =
+  | 'PERCENT_OFF_PRODUCT'
+  | 'FIXED_OFF_ORDER'
+  | 'BUY_X_GET_Y_FREE'
+  | 'BUNDLE';
+
+interface DiscountBase {
+  id: string;
+  name: string;
+  description: string;
+  active: boolean;
+}
+
+export interface PercentOffProductDiscount extends DiscountBase {
+  kind: 'PERCENT_OFF_PRODUCT';
+  productId: string;
+  percent: number; // 0-100
+}
+
+export interface FixedOffOrderDiscount extends DiscountBase {
+  kind: 'FIXED_OFF_ORDER';
+  minSubtotalCents: number;
+  amountCents: number;
+}
+
+export interface BuyXGetYFreeDiscount extends DiscountBase {
+  kind: 'BUY_X_GET_Y_FREE';
+  productId: string;
+  buyQuantity: number;
+  freeQuantity: number;
+}
+
+export interface BundleDiscount extends DiscountBase {
+  kind: 'BUNDLE';
+  productIds: string[]; // all must be present (qty >= 1) to qualify
+  amountCents: number;
+}
+
+export type Discount =
+  | PercentOffProductDiscount
+  | FixedOffOrderDiscount
+  | BuyXGetYFreeDiscount
+  | BundleDiscount;

--- a/bff/src/discounts/discount.entity.ts
+++ b/bff/src/discounts/discount.entity.ts
@@ -3,7 +3,8 @@
  *
  * - PERCENT_OFF_PRODUCT: e.g. 20% off coffee beans
  * - FIXED_OFF_ORDER: e.g. £5 off when subtotal >= £30
- * - BUY_X_GET_Y_FREE: e.g. buy 2 oat milks, get 1 free (cheapest among the matching items is free)
+ * - BUY_X_GET_Y_FREE: classic "buy X, get Y free" — for every (X+Y) in the cart,
+ *     Y are free. e.g. buyQuantity=2, freeQuantity=1 means qty 3 → pay for 2.
  * - BUNDLE: e.g. coffee + oat milk together = £2 off
  */
 export type DiscountKind =

--- a/bff/src/discounts/discounts.controller.ts
+++ b/bff/src/discounts/discounts.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { DiscountsService } from './discounts.service';
+import { Discount } from './discount.entity';
+
+@Controller('discounts')
+export class DiscountsController {
+  constructor(private readonly discounts: DiscountsService) {}
+
+  @Get()
+  list(): Discount[] {
+    return this.discounts.list();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string): Discount {
+    return this.discounts.get(id);
+  }
+}

--- a/bff/src/discounts/discounts.module.ts
+++ b/bff/src/discounts/discounts.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DiscountsController } from './discounts.controller';
+import { DiscountsService } from './discounts.service';
+import { DiscountEngine } from './discount-engine';
+
+@Module({
+  controllers: [DiscountsController],
+  providers: [DiscountsService, DiscountEngine],
+  exports: [DiscountsService, DiscountEngine],
+})
+export class DiscountsModule {}

--- a/bff/src/discounts/discounts.seed.ts
+++ b/bff/src/discounts/discounts.seed.ts
@@ -1,0 +1,41 @@
+import { Discount } from './discount.entity';
+
+export const DISCOUNT_SEED: Discount[] = [
+  {
+    id: 'd-coffee-20',
+    name: '20% off coffee beans',
+    description: 'Save 20% on every bag of single-origin coffee beans.',
+    active: true,
+    kind: 'PERCENT_OFF_PRODUCT',
+    productId: 'p-coffee-beans',
+    percent: 20,
+  },
+  {
+    id: 'd-order-5-over-30',
+    name: '£5 off when you spend £30',
+    description: 'Spend £30 or more and we take £5 off your order.',
+    active: true,
+    kind: 'FIXED_OFF_ORDER',
+    minSubtotalCents: 3000,
+    amountCents: 500,
+  },
+  {
+    id: 'd-oat-milk-3-for-2',
+    name: 'Oat milk: 3 for 2',
+    description: 'Buy 2 oat milks, get 1 free.',
+    active: true,
+    kind: 'BUY_X_GET_Y_FREE',
+    productId: 'p-oat-milk',
+    buyQuantity: 2,
+    freeQuantity: 1,
+  },
+  {
+    id: 'd-coffee-oatmilk-bundle',
+    name: 'Coffee & oat milk bundle',
+    description: 'Buy coffee beans and oat milk together — save £2.',
+    active: true,
+    kind: 'BUNDLE',
+    productIds: ['p-coffee-beans', 'p-oat-milk'],
+    amountCents: 200,
+  },
+];

--- a/bff/src/discounts/discounts.service.ts
+++ b/bff/src/discounts/discounts.service.ts
@@ -1,0 +1,29 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Discount } from './discount.entity';
+import { DISCOUNT_SEED } from './discounts.seed';
+
+@Injectable()
+export class DiscountsService {
+  private readonly discounts = new Map<string, Discount>();
+
+  constructor() {
+    DISCOUNT_SEED.forEach((d) => this.discounts.set(d.id, { ...d }));
+  }
+
+  list(): Discount[] {
+    return Array.from(this.discounts.values())
+      .filter((d) => d.active)
+      .map((d) => ({ ...d }));
+  }
+
+  get(id: string): Discount {
+    const d = this.discounts.get(id);
+    if (!d) throw new NotFoundException(`Discount ${id} not found`);
+    return { ...d };
+  }
+
+  /** Returns active discounts for the engine to evaluate against a cart. */
+  active(): Discount[] {
+    return Array.from(this.discounts.values()).filter((d) => d.active);
+  }
+}


### PR DESCRIPTION
## Summary
- Pure pricing engine: cart lines + active discounts → \`{subtotal, applied[], discountTotal, total}\`
- Four promo kinds: PERCENT_OFF_PRODUCT, FIXED_OFF_ORDER, BUY_X_GET_Y_FREE, BUNDLE
- Order matters: product-scoped promos compute first; FIXED_OFF_ORDER threshold checks post-product-discount subtotal
- 9 unit tests cover each promo kind, threshold edge, and the negative-total guard

## Test plan
- [x] \`npm test\` — 9 engine cases pass
- [x] Bundle requires all products present, multiplied by min line qty
- [x] 3-for-2 doesn't fire below threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)