### PR TITLE
feat(bff): cart module with 2-minute reservation TTL

### DIFF
--- a/bff/src/carts/cart.entity.ts
+++ b/bff/src/carts/cart.entity.ts
@@ -1,0 +1,14 @@
+export type CartStatus = 'active' | 'checked_out' | 'expired';
+
+export interface CartLine {
+  productId: string;
+  quantity: number;
+}
+
+export interface Cart {
+  id: string;
+  status: CartStatus;
+  lines: CartLine[];
+  createdAt: number;
+  lastActivityAt: number;
+}

--- a/bff/src/carts/carts.controller.ts
+++ b/bff/src/carts/carts.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { Cart } from './cart.entity';
+import { CartsService } from './carts.service';
+import { AddItemDto, UpdateItemDto } from './dto';
+
+@Controller('carts')
+export class CartsController {
+  constructor(private readonly carts: CartsService) {}
+
+  @Post()
+  create(): Cart {
+    return this.carts.create();
+  }
+
+  @Get(':id')
+  get(@Param('id') id: string): Cart {
+    return this.carts.get(id);
+  }
+
+  @Post(':id/items')
+  addItem(@Param('id') id: string, @Body() body: AddItemDto): Cart {
+    return this.carts.addItem(id, body.productId, body.quantity);
+  }
+
+  @Patch(':id/items/:productId')
+  updateItem(
+    @Param('id') id: string,
+    @Param('productId') productId: string,
+    @Body() body: UpdateItemDto,
+  ): Cart {
+    return this.carts.updateItem(id, productId, body.quantity);
+  }
+
+  @Delete(':id/items/:productId')
+  removeItem(
+    @Param('id') id: string,
+    @Param('productId') productId: string,
+  ): Cart {
+    return this.carts.removeItem(id, productId);
+  }
+}

--- a/bff/src/carts/carts.module.ts
+++ b/bff/src/carts/carts.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ProductsModule } from '../products/products.module';
+import { CartsController } from './carts.controller';
+import { CartsService } from './carts.service';
+
+@Module({
+  imports: [ProductsModule],
+  controllers: [CartsController],
+  providers: [CartsService],
+  exports: [CartsService],
+})
+export class CartsModule {}

--- a/bff/src/carts/carts.service.spec.ts
+++ b/bff/src/carts/carts.service.spec.ts
@@ -1,0 +1,75 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ProductsService } from '../products/products.service';
+import { CartsService, RESERVATION_TTL_MS } from './carts.service';
+
+describe('CartsService', () => {
+  let products: ProductsService;
+  let carts: CartsService;
+
+  beforeEach(() => {
+    products = new ProductsService();
+    carts = new CartsService(products);
+  });
+
+  afterEach(() => {
+    carts.onModuleDestroy();
+  });
+
+  it('creates an empty active cart', () => {
+    const cart = carts.create();
+    expect(cart.status).toBe('active');
+    expect(cart.lines).toEqual([]);
+  });
+
+  it('reserves stock when adding items', () => {
+    const cart = carts.create();
+    const before = products.get('p-coffee-beans').stock;
+    carts.addItem(cart.id, 'p-coffee-beans', 2);
+    expect(products.get('p-coffee-beans').stock).toBe(before - 2);
+  });
+
+  it('rejects adding more than available stock', () => {
+    const cart = carts.create();
+    expect(() => carts.addItem(cart.id, 'p-tomato-sauce', 1)).toThrow(BadRequestException);
+  });
+
+  it('combines quantities when the same product is added twice', () => {
+    const cart = carts.create();
+    carts.addItem(cart.id, 'p-coffee-beans', 1);
+    const updated = carts.addItem(cart.id, 'p-coffee-beans', 2);
+    expect(updated.lines).toHaveLength(1);
+    expect(updated.lines[0].quantity).toBe(3);
+  });
+
+  it('releases stock when the line is removed', () => {
+    const cart = carts.create();
+    const before = products.get('p-coffee-beans').stock;
+    carts.addItem(cart.id, 'p-coffee-beans', 2);
+    carts.removeItem(cart.id, 'p-coffee-beans');
+    expect(products.get('p-coffee-beans').stock).toBe(before);
+  });
+
+  it('updateItem reconciles delta against inventory', () => {
+    const cart = carts.create();
+    carts.addItem(cart.id, 'p-coffee-beans', 2);
+    const beforeRaise = products.get('p-coffee-beans').stock;
+    carts.updateItem(cart.id, 'p-coffee-beans', 5);
+    expect(products.get('p-coffee-beans').stock).toBe(beforeRaise - 3);
+    carts.updateItem(cart.id, 'p-coffee-beans', 1);
+    expect(products.get('p-coffee-beans').stock).toBe(beforeRaise + 1);
+  });
+
+  it('expires carts after TTL of inactivity and releases reservations', () => {
+    const cart = carts.create();
+    carts.addItem(cart.id, 'p-coffee-beans', 2);
+    const reservedAt = products.get('p-coffee-beans').stock;
+    const future = Date.now() + RESERVATION_TTL_MS + 1000;
+    carts.sweepExpired(future);
+    expect(products.get('p-coffee-beans').stock).toBe(reservedAt + 2);
+    expect(() => carts.addItem(cart.id, 'p-coffee-beans', 1)).toThrow(BadRequestException);
+  });
+
+  it('throws NotFound for unknown cart', () => {
+    expect(() => carts.get('nope')).toThrow(NotFoundException);
+  });
+});

--- a/bff/src/carts/carts.service.ts
+++ b/bff/src/carts/carts.service.ts
@@ -1,0 +1,132 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
+import { ProductsService } from '../products/products.service';
+import { Cart } from './cart.entity';
+
+export const RESERVATION_TTL_MS = 2 * 60 * 1000; // 2 minutes
+const SWEEP_INTERVAL_MS = 5_000;
+
+@Injectable()
+export class CartsService implements OnModuleDestroy {
+  private readonly logger = new Logger(CartsService.name);
+  private readonly carts = new Map<string, Cart>();
+  private readonly sweepHandle: NodeJS.Timeout;
+
+  constructor(private readonly products: ProductsService) {
+    this.sweepHandle = setInterval(() => this.sweepExpired(), SWEEP_INTERVAL_MS);
+    // Don't keep the process alive solely for the sweeper.
+    this.sweepHandle.unref?.();
+  }
+
+  onModuleDestroy(): void {
+    clearInterval(this.sweepHandle);
+  }
+
+  create(): Cart {
+    const now = Date.now();
+    const cart: Cart = {
+      id: uuid(),
+      status: 'active',
+      lines: [],
+      createdAt: now,
+      lastActivityAt: now,
+    };
+    this.carts.set(cart.id, cart);
+    return { ...cart, lines: [...cart.lines] };
+  }
+
+  get(id: string): Cart {
+    this.sweepExpired();
+    const cart = this.carts.get(id);
+    if (!cart) throw new NotFoundException(`Cart ${id} not found`);
+    return { ...cart, lines: cart.lines.map((l) => ({ ...l })) };
+  }
+
+  addItem(cartId: string, productId: string, quantity: number): Cart {
+    const cart = this.requireActive(cartId);
+    this.products.reserveStockOrThrow(productId, quantity);
+    const existing = cart.lines.find((l) => l.productId === productId);
+    if (existing) {
+      existing.quantity += quantity;
+    } else {
+      cart.lines.push({ productId, quantity });
+    }
+    this.touch(cart);
+    return this.get(cartId);
+  }
+
+  updateItem(cartId: string, productId: string, quantity: number): Cart {
+    const cart = this.requireActive(cartId);
+    const line = cart.lines.find((l) => l.productId === productId);
+    if (!line) throw new NotFoundException(`Item ${productId} not in cart`);
+
+    if (quantity === 0) {
+      this.products.releaseStock(productId, line.quantity);
+      cart.lines = cart.lines.filter((l) => l.productId !== productId);
+      this.touch(cart);
+      return this.get(cartId);
+    }
+
+    const delta = quantity - line.quantity;
+    if (delta > 0) {
+      this.products.reserveStockOrThrow(productId, delta);
+    } else if (delta < 0) {
+      this.products.releaseStock(productId, -delta);
+    }
+    line.quantity = quantity;
+    this.touch(cart);
+    return this.get(cartId);
+  }
+
+  removeItem(cartId: string, productId: string): Cart {
+    return this.updateItem(cartId, productId, 0);
+  }
+
+  /** Releases all reservations for a cart. Used by checkout (success or fail) and expiry. */
+  releaseReservations(cartId: string, reason: 'checkout' | 'expiry'): void {
+    const cart = this.carts.get(cartId);
+    if (!cart || cart.status !== 'active') return;
+    for (const line of cart.lines) {
+      this.products.releaseStock(line.productId, line.quantity);
+    }
+    cart.status = reason === 'checkout' ? 'checked_out' : 'expired';
+  }
+
+  /** Marks a cart as checked out and clears any held lines. Stock has already moved to fulfilled. */
+  markCheckedOut(cartId: string): void {
+    const cart = this.carts.get(cartId);
+    if (!cart) return;
+    cart.status = 'checked_out';
+  }
+
+  /** Periodic sweep — releases reservations for any active cart idle longer than the TTL. */
+  sweepExpired(now: number = Date.now()): void {
+    for (const cart of this.carts.values()) {
+      if (cart.status !== 'active') continue;
+      if (now - cart.lastActivityAt > RESERVATION_TTL_MS) {
+        this.logger.log(`Cart ${cart.id} expired — releasing ${cart.lines.length} reservations`);
+        this.releaseReservations(cart.id, 'expiry');
+      }
+    }
+  }
+
+  private requireActive(cartId: string): Cart {
+    this.sweepExpired();
+    const cart = this.carts.get(cartId);
+    if (!cart) throw new NotFoundException(`Cart ${cartId} not found`);
+    if (cart.status !== 'active') {
+      throw new BadRequestException(`Cart ${cartId} is ${cart.status}`);
+    }
+    return cart;
+  }
+
+  private touch(cart: Cart): void {
+    cart.lastActivityAt = Date.now();
+  }
+}

--- a/bff/src/carts/carts.service.ts
+++ b/bff/src/carts/carts.service.ts
@@ -88,17 +88,23 @@ export class CartsService implements OnModuleDestroy {
     return this.updateItem(cartId, productId, 0);
   }
 
-  /** Releases all reservations for a cart. Used by checkout (success or fail) and expiry. */
-  releaseReservations(cartId: string, reason: 'checkout' | 'expiry'): void {
+  /**
+   * Use this when stock should return to inventory — i.e. on cart EXPIRY only. The product was
+   * never sold, so the held units go back. Not called for successful checkout (see markCheckedOut).
+   */
+  releaseReservations(cartId: string, reason: 'expiry'): void {
     const cart = this.carts.get(cartId);
     if (!cart || cart.status !== 'active') return;
     for (const line of cart.lines) {
       this.products.releaseStock(line.productId, line.quantity);
     }
-    cart.status = reason === 'checkout' ? 'checked_out' : 'expired';
+    cart.status = reason === 'expiry' ? 'expired' : 'checked_out';
   }
 
-  /** Marks a cart as checked out and clears any held lines. Stock has already moved to fulfilled. */
+  /**
+   * Use this on SUCCESSFUL checkout. The held stock has been "sold" — we keep the decrement
+   * and just transition the cart out of the active state so it can't be mutated further.
+   */
   markCheckedOut(cartId: string): void {
     const cart = this.carts.get(cartId);
     if (!cart) return;

--- a/bff/src/carts/dto.ts
+++ b/bff/src/carts/dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, IsString, Min } from 'class-validator';
+
+export class AddItemDto {
+  @IsString()
+  productId!: string;
+
+  @IsInt()
+  @Min(1)
+  quantity!: number;
+}
+
+export class UpdateItemDto {
+  @IsInt()
+  @Min(0)
+  quantity!: number;
+}


### PR DESCRIPTION
## Summary
- POST /carts → new cart id; GET/POST/PATCH/DELETE on items
- Reservations held by decrementing product stock at add-to-cart time (via Products primitives)
- Idle TTL: 2 minutes — sweeper runs every 5s, releases reservations on idle carts, transitions to \`expired\`
- \`onModuleDestroy\` clears the interval; \`unref()\` keeps it from blocking process exit
- 8 unit tests including TTL expiry and delta-based stock reconciliation

## Test plan
- [x] \`npm test\` — 8 cart cases pass
- [x] Adding then expiring releases the held stock
- [x] Update item by 0 removes the line