### PR TITLE
feat(bff): checkout endpoint with auto-applied discounts + e2e tests

### DIFF
--- a/bff/src/checkout/checkout.controller.ts
+++ b/bff/src/checkout/checkout.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Param, Post } from '@nestjs/common';
+import { CheckoutService } from './checkout.service';
+import { OrderSummary } from './order.entity';
+
+@Controller('carts')
+export class CheckoutController {
+  constructor(private readonly checkout: CheckoutService) {}
+
+  @Post(':id/checkout')
+  doCheckout(@Param('id') id: string): OrderSummary {
+    return this.checkout.checkout(id);
+  }
+}

--- a/bff/src/checkout/checkout.module.ts
+++ b/bff/src/checkout/checkout.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { CartsModule } from '../carts/carts.module';
+import { DiscountsModule } from '../discounts/discounts.module';
+import { ProductsModule } from '../products/products.module';
+import { CheckoutController } from './checkout.controller';
+import { CheckoutService } from './checkout.service';
+
+@Module({
+  imports: [CartsModule, ProductsModule, DiscountsModule],
+  controllers: [CheckoutController],
+  providers: [CheckoutService],
+})
+export class CheckoutModule {}

--- a/bff/src/checkout/checkout.service.spec.ts
+++ b/bff/src/checkout/checkout.service.spec.ts
@@ -1,0 +1,51 @@
+import { BadRequestException } from '@nestjs/common';
+import { CartsService } from '../carts/carts.service';
+import { DiscountEngine } from '../discounts/discount-engine';
+import { DiscountsService } from '../discounts/discounts.service';
+import { ProductsService } from '../products/products.service';
+import { CheckoutService } from './checkout.service';
+
+describe('CheckoutService', () => {
+  let products: ProductsService;
+  let carts: CartsService;
+  let checkout: CheckoutService;
+
+  beforeEach(() => {
+    products = new ProductsService();
+    carts = new CartsService(products);
+    const discounts = new DiscountsService();
+    checkout = new CheckoutService(carts, products, new DiscountEngine(discounts));
+  });
+
+  afterEach(() => {
+    carts.onModuleDestroy();
+  });
+
+  it('completes a successful checkout, returns order summary, leaves stock decremented', () => {
+    const cart = carts.create();
+    const before = products.get('p-coffee-beans').stock;
+    carts.addItem(cart.id, 'p-coffee-beans', 1);
+    carts.addItem(cart.id, 'p-oat-milk', 1);
+
+    const order = checkout.checkout(cart.id);
+    expect(order.lines).toHaveLength(2);
+    expect(order.totalCents).toBeGreaterThan(0);
+    expect(order.discounts.length).toBeGreaterThan(0); // bundle + percent should fire
+    expect(products.get('p-coffee-beans').stock).toBe(before - 1);
+
+    // Cart is now checked out.
+    expect(() => checkout.checkout(cart.id)).toThrow(BadRequestException);
+  });
+
+  it('rejects checkout of an empty cart', () => {
+    const cart = carts.create();
+    expect(() => checkout.checkout(cart.id)).toThrow(BadRequestException);
+  });
+
+  it('rejects checkout of a cart that has expired', () => {
+    const cart = carts.create();
+    carts.addItem(cart.id, 'p-coffee-beans', 1);
+    carts.sweepExpired(Date.now() + 10 * 60 * 1000);
+    expect(() => checkout.checkout(cart.id)).toThrow(BadRequestException);
+  });
+});

--- a/bff/src/checkout/checkout.service.ts
+++ b/bff/src/checkout/checkout.service.ts
@@ -1,0 +1,70 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
+import { CartsService } from '../carts/carts.service';
+import { DiscountEngine } from '../discounts/discount-engine';
+import { ProductsService } from '../products/products.service';
+import { OrderLine, OrderSummary } from './order.entity';
+
+@Injectable()
+export class CheckoutService {
+  constructor(
+    private readonly carts: CartsService,
+    private readonly products: ProductsService,
+    private readonly engine: DiscountEngine,
+  ) {}
+
+  /**
+   * Checkout flow:
+   *  1. Reload cart (also runs the expiry sweep — an idle cart fails fast).
+   *  2. Verify each line still resolves to a known product. Stock is already reserved
+   *     (we decremented at add-to-cart time), so we don't re-check inventory here —
+   *     the reservation IS the guarantee. If the cart is empty, fail with a clear message.
+   *  3. Price the cart through the discount engine (auto-applies qualifying promos).
+   *  4. Mark the cart checked out so reservations are not released back to inventory
+   *     (the items have been "purchased" — stock stays decremented).
+   *  5. Build and return the order summary.
+   *
+   * Failure surface area is small because reservations make checkout near-deterministic:
+   * the only realistic failures are an unknown cart, an empty cart, or an already-completed cart.
+   */
+  checkout(cartId: string): OrderSummary {
+    const cart = this.carts.get(cartId); // sweeps expiry; throws if expired/checked_out
+    if (cart.status !== 'active') {
+      throw new BadRequestException(`Cart ${cartId} is ${cart.status} — start a new cart`);
+    }
+    if (cart.lines.length === 0) {
+      throw new BadRequestException('Cart is empty');
+    }
+
+    const enrichedLines = cart.lines.map((line) => {
+      const product = this.products.get(line.productId);
+      return { product, quantity: line.quantity };
+    });
+
+    const pricing = this.engine.price(enrichedLines);
+
+    // The reservation has already taken stock out of inventory. Marking the cart as
+    // checked-out finalises the sale — we don't release the reservation back.
+    this.carts.markCheckedOut(cartId);
+
+    const orderLines: OrderLine[] = enrichedLines.map(({ product, quantity }) => ({
+      productId: product.id,
+      name: product.name,
+      unitPriceCents: product.priceCents,
+      quantity,
+      lineTotalCents: product.priceCents * quantity,
+    }));
+
+    return {
+      orderId: uuid(),
+      cartId,
+      placedAt: new Date().toISOString(),
+      lines: orderLines,
+      subtotalCents: pricing.subtotalCents,
+      discounts: pricing.applied,
+      discountTotalCents: pricing.discountTotalCents,
+      totalCents: pricing.totalCents,
+      currency: 'GBP',
+    };
+  }
+}

--- a/bff/src/checkout/order.entity.ts
+++ b/bff/src/checkout/order.entity.ts
@@ -1,0 +1,21 @@
+import { AppliedDiscount } from '../discounts/discount-engine';
+
+export interface OrderLine {
+  productId: string;
+  name: string;
+  unitPriceCents: number;
+  quantity: number;
+  lineTotalCents: number;
+}
+
+export interface OrderSummary {
+  orderId: string;
+  cartId: string;
+  placedAt: string;
+  lines: OrderLine[];
+  subtotalCents: number;
+  discounts: AppliedDiscount[];
+  discountTotalCents: number;
+  totalCents: number;
+  currency: 'GBP';
+}

--- a/bff/test/app.e2e-spec.ts
+++ b/bff/test/app.e2e-spec.ts
@@ -1,0 +1,76 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/http-exception.filter';
+
+describe('Retail BFF (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    app.useGlobalFilters(new HttpExceptionFilter());
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /api/products returns the catalogue', async () => {
+    const res = await request(app.getHttpServer()).get('/api/products').expect(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('GET /api/discounts returns active discounts', async () => {
+    const res = await request(app.getHttpServer()).get('/api/discounts').expect(200);
+    expect(res.body.every((d: { active: boolean }) => d.active)).toBe(true);
+  });
+
+  it('completes a happy-path cart -> checkout flow', async () => {
+    const server = app.getHttpServer();
+
+    const cart = (await request(server).post('/api/carts').expect(201)).body;
+    expect(cart.id).toBeDefined();
+
+    await request(server)
+      .post(`/api/carts/${cart.id}/items`)
+      .send({ productId: 'p-coffee-beans', quantity: 1 })
+      .expect(201);
+
+    await request(server)
+      .post(`/api/carts/${cart.id}/items`)
+      .send({ productId: 'p-oat-milk', quantity: 3 })
+      .expect(201);
+
+    const order = (
+      await request(server).post(`/api/carts/${cart.id}/checkout`).expect(201)
+    ).body;
+
+    expect(order.orderId).toBeDefined();
+    expect(order.lines).toHaveLength(2);
+    expect(order.discountTotalCents).toBeGreaterThan(0);
+    expect(order.totalCents).toBeLessThan(order.subtotalCents);
+  });
+
+  it('returns 400 when adding out-of-stock item', async () => {
+    const server = app.getHttpServer();
+    const cart = (await request(server).post('/api/carts').expect(201)).body;
+    const res = await request(server)
+      .post(`/api/carts/${cart.id}/items`)
+      .send({ productId: 'p-tomato-sauce', quantity: 1 })
+      .expect(400);
+    expect(res.body.message).toMatch(/Insufficient stock/);
+  });
+
+  it('returns 400 when checking out an empty cart', async () => {
+    const server = app.getHttpServer();
+    const cart = (await request(server).post('/api/carts').expect(201)).body;
+    const res = await request(server).post(`/api/carts/${cart.id}/checkout`).expect(400);
+    expect(res.body.message).toMatch(/empty/i);
+  });
+});

--- a/bff/test/app.e2e-spec.ts
+++ b/bff/test/app.e2e-spec.ts
@@ -31,8 +31,11 @@ describe('Retail BFF (e2e)', () => {
     expect(res.body.every((d: { active: boolean }) => d.active)).toBe(true);
   });
 
-  it('completes a happy-path cart -> checkout flow', async () => {
+  it('completes a happy-path cart -> checkout flow and decrements catalogue stock', async () => {
     const server = app.getHttpServer();
+
+    const coffeeBefore = (await request(server).get('/api/products/p-coffee-beans')).body.stock;
+    const oatBefore = (await request(server).get('/api/products/p-oat-milk')).body.stock;
 
     const cart = (await request(server).post('/api/carts').expect(201)).body;
     expect(cart.id).toBeDefined();
@@ -55,6 +58,12 @@ describe('Retail BFF (e2e)', () => {
     expect(order.lines).toHaveLength(2);
     expect(order.discountTotalCents).toBeGreaterThan(0);
     expect(order.totalCents).toBeLessThan(order.subtotalCents);
+
+    // Sale moves the held reservation into "sold" — stock stays decremented.
+    const coffeeAfter = (await request(server).get('/api/products/p-coffee-beans')).body.stock;
+    const oatAfter = (await request(server).get('/api/products/p-oat-milk')).body.stock;
+    expect(coffeeAfter).toBe(coffeeBefore - 1);
+    expect(oatAfter).toBe(oatBefore - 3);
   });
 
   it('returns 400 when adding out-of-stock item', async () => {

--- a/bff/test/jest-e2e.json
+++ b/bff/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}


### PR DESCRIPTION
## Summary
- POST /carts/:id/checkout — auto-applies qualifying discounts via the engine, returns OrderSummary
- Held stock stays decremented on success (sale), released only on expiry
- 3 unit tests for checkout service + 5 e2e tests covering the full HTTP flow
- \`npm test\` now runs unit + e2e

## Test plan
- [x] Unit + e2e green (37 + 5 = 42 cases)
- [x] Empty cart returns 400 with readable message
- [x] Re-checkout of a checked-out cart returns 400