### PR TITLE
feat(mobile): Expo scaffold + API client + cart state

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3000/api

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,20 @@
+{
+  "expo": {
+    "name": "Retail Shopping",
+    "slug": "retail-shopping",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "newArchEnabled": false,
+    "splash": {
+      "backgroundColor": "#ffffff"
+    },
+    "assetBundlePatterns": ["**/*"],
+    "ios": { "supportsTablet": true },
+    "android": { "adaptiveIcon": { "backgroundColor": "#ffffff" } },
+    "web": { "favicon": "./assets/favicon.png" },
+    "extra": {
+      "apiBaseUrl": "http://localhost:3000/api"
+    }
+  }
+}

--- a/mobile/babel.config.js
+++ b/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -1,0 +1,2 @@
+// Provide a default API base URL for tests so Constants.expoConfig is not needed.
+process.env.EXPO_PUBLIC_API_BASE_URL = 'http://localhost:3000/api';

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "mobile",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@react-navigation/native": "^6.1.18",
+    "@react-navigation/native-stack": "^6.11.0",
+    "expo": "~51.0.28",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.5",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "3.31.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.7",
+    "@testing-library/react-native": "^12.5.1",
+    "@types/jest": "^29.5.12",
+    "@types/react": "~18.2.79",
+    "jest": "^29.7.0",
+    "jest-expo": "~51.0.3",
+    "react-test-renderer": "18.2.0",
+    "typescript": "~5.3.3"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg))"
+    ],
+    "setupFiles": ["./jest.setup.js"]
+  }
+}

--- a/mobile/src/CartContext.tsx
+++ b/mobile/src/CartContext.tsx
@@ -3,8 +3,8 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { api } from './api';
@@ -33,6 +33,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [cart, setCart] = useState<Cart | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Holds the in-flight createCart() promise so two rapid addItem taps don't mint two carts.
+  const cartCreation = useRef<Promise<Cart> | null>(null);
+  const cartRef = useRef<Cart | null>(null);
+  cartRef.current = cart;
 
   const wrap = useCallback(async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
     setLoading(true);
@@ -62,17 +66,24 @@ export function CartProvider({ children }: { children: ReactNode }) {
     });
   }, [cart, wrap]);
 
-  const ensureCart = useCallback(async (): Promise<Cart | null> => {
-    if (cart) return cart;
-    const c = await api.createCart();
-    setCart(c);
-    return c;
-  }, [cart]);
+  const ensureCart = useCallback(async (): Promise<Cart> => {
+    if (cartRef.current) return cartRef.current;
+    if (!cartCreation.current) {
+      cartCreation.current = api.createCart().then((c) => {
+        setCart(c);
+        return c;
+      });
+      cartCreation.current.finally(() => {
+        cartCreation.current = null;
+      });
+    }
+    return cartCreation.current;
+  }, []);
 
   const addItem = useCallback(
     async (productId: string, quantity = 1) => {
       await wrap(async () => {
-        const c = (await ensureCart())!;
+        const c = await ensureCart();
         const updated = await api.addItem(c.id, productId, quantity);
         setCart(updated);
       });

--- a/mobile/src/CartContext.tsx
+++ b/mobile/src/CartContext.tsx
@@ -1,0 +1,124 @@
+import React, {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { api } from './api';
+import { Cart } from './types';
+
+interface CartContextValue {
+  cart: Cart | null;
+  loading: boolean;
+  error: string | null;
+  createCart: () => Promise<void>;
+  refresh: () => Promise<void>;
+  addItem: (productId: string, quantity?: number) => Promise<void>;
+  updateItem: (productId: string, quantity: number) => Promise<void>;
+  removeItem: (productId: string) => Promise<void>;
+  clear: () => void;
+}
+
+const CartContext = createContext<CartContextValue | null>(null);
+
+/**
+ * Single cart per session. We hold the cart id locally so the user keeps the
+ * same reservation across screens. On any mutation error we surface the message
+ * but keep the cart id intact — the BFF is the source of truth for state.
+ */
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [cart, setCart] = useState<Cart | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const wrap = useCallback(async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
+    setLoading(true);
+    setError(null);
+    try {
+      return await fn();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Something went wrong');
+      return undefined;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const createCart = useCallback(async () => {
+    await wrap(async () => {
+      const c = await api.createCart();
+      setCart(c);
+    });
+  }, [wrap]);
+
+  const refresh = useCallback(async () => {
+    if (!cart) return;
+    await wrap(async () => {
+      const c = await api.getCart(cart.id);
+      setCart(c);
+    });
+  }, [cart, wrap]);
+
+  const ensureCart = useCallback(async (): Promise<Cart | null> => {
+    if (cart) return cart;
+    const c = await api.createCart();
+    setCart(c);
+    return c;
+  }, [cart]);
+
+  const addItem = useCallback(
+    async (productId: string, quantity = 1) => {
+      await wrap(async () => {
+        const c = (await ensureCart())!;
+        const updated = await api.addItem(c.id, productId, quantity);
+        setCart(updated);
+      });
+    },
+    [ensureCart, wrap],
+  );
+
+  const updateItem = useCallback(
+    async (productId: string, quantity: number) => {
+      if (!cart) return;
+      await wrap(async () => {
+        const updated = await api.updateItem(cart.id, productId, quantity);
+        setCart(updated);
+      });
+    },
+    [cart, wrap],
+  );
+
+  const removeItem = useCallback(
+    async (productId: string) => {
+      if (!cart) return;
+      await wrap(async () => {
+        const updated = await api.removeItem(cart.id, productId);
+        setCart(updated);
+      });
+    },
+    [cart, wrap],
+  );
+
+  const clear = useCallback(() => {
+    setCart(null);
+    setError(null);
+  }, []);
+
+  // Lazy: don't create a cart until the user actually adds an item. Reservations matter.
+
+  const value = useMemo<CartContextValue>(
+    () => ({ cart, loading, error, createCart, refresh, addItem, updateItem, removeItem, clear }),
+    [cart, loading, error, createCart, refresh, addItem, updateItem, removeItem, clear],
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart(): CartContextValue {
+  const ctx = useContext(CartContext);
+  if (!ctx) throw new Error('useCart must be used inside CartProvider');
+  return ctx;
+}

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -1,0 +1,69 @@
+import Constants from 'expo-constants';
+import { Cart, OrderSummary, Product } from './types';
+
+function resolveBaseUrl(): string {
+  // Priority: explicit env > expoConfig.extra > localhost fallback (mostly for tests).
+  const fromEnv = process.env.EXPO_PUBLIC_API_BASE_URL;
+  if (fromEnv) return fromEnv;
+  const extra = Constants.expoConfig?.extra as { apiBaseUrl?: string } | undefined;
+  if (extra?.apiBaseUrl) return extra.apiBaseUrl;
+  return 'http://localhost:3000/api';
+}
+
+export const API_BASE_URL = resolveBaseUrl();
+
+class ApiError extends Error {
+  constructor(message: string, public status: number) {
+    super(message);
+  }
+}
+
+async function request<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    body = undefined;
+  }
+
+  if (!res.ok) {
+    const message =
+      (body as { message?: string | string[] } | undefined)?.message ?? `HTTP ${res.status}`;
+    throw new ApiError(Array.isArray(message) ? message.join('; ') : message, res.status);
+  }
+  return body as T;
+}
+
+export const api = {
+  listProducts: () => request<Product[]>('/products'),
+  getProduct: (id: string) => request<Product>(`/products/${id}`),
+  createCart: () => request<Cart>('/carts', { method: 'POST' }),
+  getCart: (id: string) => request<Cart>(`/carts/${id}`),
+  addItem: (cartId: string, productId: string, quantity: number) =>
+    request<Cart>(`/carts/${cartId}/items`, {
+      method: 'POST',
+      body: JSON.stringify({ productId, quantity }),
+    }),
+  updateItem: (cartId: string, productId: string, quantity: number) =>
+    request<Cart>(`/carts/${cartId}/items/${productId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ quantity }),
+    }),
+  removeItem: (cartId: string, productId: string) =>
+    request<Cart>(`/carts/${cartId}/items/${productId}`, { method: 'DELETE' }),
+  checkout: (cartId: string) =>
+    request<OrderSummary>(`/carts/${cartId}/checkout`, { method: 'POST' }),
+};
+
+export { ApiError };

--- a/mobile/src/format.ts
+++ b/mobile/src/format.ts
@@ -1,0 +1,4 @@
+export function formatGBP(cents: number): string {
+  const pounds = cents / 100;
+  return pounds.toLocaleString('en-GB', { style: 'currency', currency: 'GBP' });
+}

--- a/mobile/src/navigation.ts
+++ b/mobile/src/navigation.ts
@@ -1,0 +1,8 @@
+import { OrderSummary } from './types';
+
+export type RootStackParamList = {
+  ProductList: undefined;
+  ProductDetail: { productId: string };
+  Cart: undefined;
+  Checkout: { order: OrderSummary } | undefined;
+};

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -1,0 +1,50 @@
+export interface Product {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  priceCents: number;
+  stock: number;
+  imageUrl?: string;
+}
+
+export interface CartLine {
+  productId: string;
+  quantity: number;
+}
+
+export type CartStatus = 'active' | 'checked_out' | 'expired';
+
+export interface Cart {
+  id: string;
+  status: CartStatus;
+  lines: CartLine[];
+  createdAt: number;
+  lastActivityAt: number;
+}
+
+export interface AppliedDiscount {
+  discountId: string;
+  name: string;
+  amountCents: number;
+}
+
+export interface OrderLine {
+  productId: string;
+  name: string;
+  unitPriceCents: number;
+  quantity: number;
+  lineTotalCents: number;
+}
+
+export interface OrderSummary {
+  orderId: string;
+  cartId: string;
+  placedAt: string;
+  lines: OrderLine[];
+  subtotalCents: number;
+  discounts: AppliedDiscount[];
+  discountTotalCents: number;
+  totalCents: number;
+  currency: 'GBP';
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "jsx": "react-native",
+    "moduleResolution": "node"
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Expo + TS scaffold (Expo SDK 51 / RN 0.74)
- Typed API client wrapping fetch — base URL from EXPO_PUBLIC_API_BASE_URL > app.json extra > localhost fallback
- React Navigation native-stack types in \`navigation.ts\`
- CartProvider with lazy cart creation (don't burn reservations on browse)
- formatGBP helper

## Test plan
- [x] Types match BFF DTOs exactly
- [ ] Screens (next PR) exercise the context