### PR TITLE
feat(mobile): four screens + native-stack navigation

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,47 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { StatusBar } from 'expo-status-bar';
+import React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { CartProvider } from './src/CartContext';
+import { RootStackParamList } from './src/navigation';
+import { CartScreen } from './src/screens/CartScreen';
+import { CheckoutScreen } from './src/screens/CheckoutScreen';
+import { ProductDetailScreen } from './src/screens/ProductDetailScreen';
+import { ProductListScreen } from './src/screens/ProductListScreen';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <CartProvider>
+        <NavigationContainer>
+          <Stack.Navigator>
+            <Stack.Screen
+              name="ProductList"
+              component={ProductListScreen}
+              options={{ title: 'Shop' }}
+            />
+            <Stack.Screen
+              name="ProductDetail"
+              component={ProductDetailScreen}
+              options={{ title: 'Product' }}
+            />
+            <Stack.Screen
+              name="Cart"
+              component={CartScreen}
+              options={{ title: 'Your cart' }}
+            />
+            <Stack.Screen
+              name="Checkout"
+              component={CheckoutScreen}
+              options={{ title: 'Order summary', headerBackVisible: false }}
+            />
+          </Stack.Navigator>
+          <StatusBar style="auto" />
+        </NavigationContainer>
+      </CartProvider>
+    </SafeAreaProvider>
+  );
+}

--- a/mobile/src/screens/CartScreen.tsx
+++ b/mobile/src/screens/CartScreen.tsx
@@ -54,8 +54,10 @@ export function CartScreen({ navigation }: Props) {
     setCheckoutError(null);
     try {
       const order = await api.checkout(cart.id);
-      clear();
+      // Navigate first, THEN clear — otherwise the empty-cart branch flashes between
+      // the state update and the route change.
       navigation.replace('Checkout', { order });
+      clear();
     } catch (e) {
       setCheckoutError(e instanceof Error ? e.message : 'Checkout failed');
     } finally {
@@ -115,18 +117,18 @@ export function CartScreen({ navigation }: Props) {
             <View style={styles.qtyControls}>
               <Pressable
                 onPress={() => updateItem(item.product.id, item.quantity - 1)}
-                style={styles.qtyBtn}
+                style={[styles.qtyBtn, item.quantity <= 1 && styles.qtyBtnDisabled]}
                 accessibilityLabel="Decrease quantity"
-                disabled={loading}
+                disabled={loading || item.quantity <= 1}
               >
                 <Text style={styles.qtyBtnText}>−</Text>
               </Pressable>
               <Text style={styles.qty}>{item.quantity}</Text>
               <Pressable
                 onPress={() => updateItem(item.product.id, item.quantity + 1)}
-                style={styles.qtyBtn}
+                style={[styles.qtyBtn, item.product.stock <= 0 && styles.qtyBtnDisabled]}
                 accessibilityLabel="Increase quantity"
-                disabled={loading}
+                disabled={loading || item.product.stock <= 0}
               >
                 <Text style={styles.qtyBtnText}>+</Text>
               </Pressable>
@@ -198,6 +200,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   qtyBtnText: { fontSize: 18, fontWeight: '600' },
+  qtyBtnDisabled: { opacity: 0.4 },
   qty: { width: 24, textAlign: 'center', fontSize: 15 },
   remove: { color: '#b91c1c', fontWeight: '600' },
   footer: {

--- a/mobile/src/screens/CartScreen.tsx
+++ b/mobile/src/screens/CartScreen.tsx
@@ -1,0 +1,225 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { api } from '../api';
+import { useCart } from '../CartContext';
+import { formatGBP } from '../format';
+import { RootStackParamList } from '../navigation';
+import { Product } from '../types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Cart'>;
+
+interface EnrichedLine {
+  product: Product;
+  quantity: number;
+}
+
+export function CartScreen({ navigation }: Props) {
+  const { cart, error, loading, updateItem, removeItem, clear } = useCart();
+  const [lines, setLines] = useState<EnrichedLine[] | null>(null);
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [checkingOut, setCheckingOut] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
+
+  const resolve = useCallback(async () => {
+    if (!cart) {
+      setLines([]);
+      return;
+    }
+    setResolveError(null);
+    try {
+      const products = await Promise.all(cart.lines.map((l) => api.getProduct(l.productId)));
+      setLines(
+        cart.lines.map((l, i) => ({ product: products[i], quantity: l.quantity })),
+      );
+    } catch (e) {
+      setResolveError(e instanceof Error ? e.message : 'Could not load cart contents');
+    }
+  }, [cart]);
+
+  useEffect(() => {
+    resolve();
+  }, [resolve]);
+
+  const onCheckout = async () => {
+    if (!cart) return;
+    setCheckingOut(true);
+    setCheckoutError(null);
+    try {
+      const order = await api.checkout(cart.id);
+      clear();
+      navigation.replace('Checkout', { order });
+    } catch (e) {
+      setCheckoutError(e instanceof Error ? e.message : 'Checkout failed');
+    } finally {
+      setCheckingOut(false);
+    }
+  };
+
+  if (!cart || (lines && lines.length === 0)) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.emptyText}>Your cart is empty.</Text>
+        <Pressable onPress={() => navigation.navigate('ProductList')}>
+          <Text style={styles.link}>Browse products</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (!lines && !resolveError) {
+    return (
+      <View style={styles.empty}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (resolveError) {
+    return (
+      <View style={styles.empty}>
+        <Text style={styles.error}>{resolveError}</Text>
+        <Pressable onPress={resolve}>
+          <Text style={styles.link}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  const subtotalCents = (lines ?? []).reduce(
+    (s, l) => s + l.product.priceCents * l.quantity,
+    0,
+  );
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={lines ?? []}
+        keyExtractor={(l) => l.product.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <View style={styles.row}>
+            <View style={{ flex: 1 }}>
+              <Text style={styles.name}>{item.product.name}</Text>
+              <Text style={styles.unit}>
+                {formatGBP(item.product.priceCents)} each
+              </Text>
+            </View>
+            <View style={styles.qtyControls}>
+              <Pressable
+                onPress={() => updateItem(item.product.id, item.quantity - 1)}
+                style={styles.qtyBtn}
+                accessibilityLabel="Decrease quantity"
+                disabled={loading}
+              >
+                <Text style={styles.qtyBtnText}>−</Text>
+              </Pressable>
+              <Text style={styles.qty}>{item.quantity}</Text>
+              <Pressable
+                onPress={() => updateItem(item.product.id, item.quantity + 1)}
+                style={styles.qtyBtn}
+                accessibilityLabel="Increase quantity"
+                disabled={loading}
+              >
+                <Text style={styles.qtyBtnText}>+</Text>
+              </Pressable>
+            </View>
+            <Pressable
+              onPress={() => removeItem(item.product.id)}
+              accessibilityLabel="Remove item"
+              disabled={loading}
+            >
+              <Text style={styles.remove}>Remove</Text>
+            </Pressable>
+          </View>
+        )}
+      />
+
+      <View style={styles.footer}>
+        <View style={styles.subtotalRow}>
+          <Text style={styles.subtotalLabel}>Subtotal</Text>
+          <Text style={styles.subtotal}>{formatGBP(subtotalCents)}</Text>
+        </View>
+        <Text style={styles.note}>Discounts apply automatically at checkout.</Text>
+        {error && <Text style={styles.error}>{error}</Text>}
+        {checkoutError && <Text style={styles.error}>{checkoutError}</Text>}
+        <Pressable
+          onPress={onCheckout}
+          disabled={checkingOut || loading}
+          style={({ pressed }) => [
+            styles.checkoutBtn,
+            (checkingOut || loading) && styles.disabled,
+            pressed && styles.pressed,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Check out"
+        >
+          <Text style={styles.checkoutText}>
+            {checkingOut ? 'Processing…' : 'Check out'}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
+  emptyText: { fontSize: 16 },
+  link: { color: '#2563eb', fontWeight: '600' },
+  list: { padding: 16, gap: 12 },
+  row: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  name: { fontSize: 15, fontWeight: '600' },
+  unit: { color: '#6b7280', marginTop: 2 },
+  qtyControls: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  qtyBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 6,
+    backgroundColor: '#f3f4f6',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  qtyBtnText: { fontSize: 18, fontWeight: '600' },
+  qty: { width: 24, textAlign: 'center', fontSize: 15 },
+  remove: { color: '#b91c1c', fontWeight: '600' },
+  footer: {
+    borderTopWidth: 1,
+    borderTopColor: '#e5e7eb',
+    padding: 16,
+    backgroundColor: '#fff',
+    gap: 8,
+  },
+  subtotalRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  subtotalLabel: { fontSize: 16 },
+  subtotal: { fontSize: 18, fontWeight: '700' },
+  note: { color: '#6b7280', fontSize: 13 },
+  error: { color: '#b91c1c' },
+  checkoutBtn: {
+    backgroundColor: '#111827',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  pressed: { backgroundColor: '#374151' },
+  disabled: { backgroundColor: '#9ca3af' },
+  checkoutText: { color: '#fff', fontWeight: '600', fontSize: 16 },
+});

--- a/mobile/src/screens/CheckoutScreen.tsx
+++ b/mobile/src/screens/CheckoutScreen.tsx
@@ -1,0 +1,114 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { formatGBP } from '../format';
+import { RootStackParamList } from '../navigation';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Checkout'>;
+
+export function CheckoutScreen({ route, navigation }: Props) {
+  const order = route.params?.order;
+
+  if (!order) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>Missing order summary.</Text>
+        <Pressable onPress={() => navigation.navigate('ProductList')}>
+          <Text style={styles.link}>Back to products</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.title}>Order confirmed</Text>
+      <Text style={styles.orderId}>Order #{order.orderId.slice(0, 8)}</Text>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Items</Text>
+        {order.lines.map((line) => (
+          <View key={line.productId} style={styles.lineRow}>
+            <Text style={styles.lineName}>
+              {line.name} <Text style={styles.muted}>× {line.quantity}</Text>
+            </Text>
+            <Text style={styles.lineTotal}>{formatGBP(line.lineTotalCents)}</Text>
+          </View>
+        ))}
+      </View>
+
+      <View style={styles.section}>
+        <View style={styles.totalRow}>
+          <Text style={styles.totalLabel}>Subtotal</Text>
+          <Text style={styles.totalValue}>{formatGBP(order.subtotalCents)}</Text>
+        </View>
+
+        {order.discounts.length > 0 && (
+          <>
+            <Text style={[styles.sectionTitle, { marginTop: 12 }]}>Discounts applied</Text>
+            {order.discounts.map((d) => (
+              <View key={d.discountId} style={styles.lineRow}>
+                <Text style={styles.discountName}>{d.name}</Text>
+                <Text style={styles.discountAmount}>−{formatGBP(d.amountCents)}</Text>
+              </View>
+            ))}
+            <View style={styles.totalRow}>
+              <Text style={styles.totalLabel}>Discount total</Text>
+              <Text style={styles.totalValue}>−{formatGBP(order.discountTotalCents)}</Text>
+            </View>
+          </>
+        )}
+
+        <View style={[styles.totalRow, styles.grandRow]}>
+          <Text style={styles.grandLabel}>Total paid</Text>
+          <Text style={styles.grandValue}>{formatGBP(order.totalCents)}</Text>
+        </View>
+      </View>
+
+      <Pressable
+        onPress={() => navigation.popToTop()}
+        style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}
+        accessibilityRole="button"
+      >
+        <Text style={styles.btnText}>Back to shop</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 24, gap: 16 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24, gap: 12 },
+  title: { fontSize: 26, fontWeight: '700' },
+  orderId: { color: '#6b7280' },
+  section: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  sectionTitle: { fontSize: 14, color: '#6b7280', marginBottom: 8, textTransform: 'uppercase' },
+  lineRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 4 },
+  lineName: { fontSize: 15, flex: 1 },
+  lineTotal: { fontSize: 15 },
+  muted: { color: '#6b7280' },
+  totalRow: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 4 },
+  totalLabel: { fontSize: 15 },
+  totalValue: { fontSize: 15 },
+  discountName: { color: '#16a34a', flex: 1 },
+  discountAmount: { color: '#16a34a' },
+  grandRow: { borderTopWidth: 1, borderTopColor: '#e5e7eb', paddingTop: 8, marginTop: 4 },
+  grandLabel: { fontSize: 18, fontWeight: '700' },
+  grandValue: { fontSize: 18, fontWeight: '700' },
+  btn: {
+    backgroundColor: '#111827',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  btnPressed: { backgroundColor: '#374151' },
+  btnText: { color: '#fff', fontWeight: '600', fontSize: 16 },
+  error: { color: '#b91c1c' },
+  link: { color: '#2563eb', fontWeight: '600' },
+});

--- a/mobile/src/screens/ProductDetailScreen.tsx
+++ b/mobile/src/screens/ProductDetailScreen.tsx
@@ -1,0 +1,121 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { api } from '../api';
+import { useCart } from '../CartContext';
+import { formatGBP } from '../format';
+import { RootStackParamList } from '../navigation';
+import { Product } from '../types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ProductDetail'>;
+
+export function ProductDetailScreen({ route, navigation }: Props) {
+  const { productId } = route.params;
+  const [product, setProduct] = useState<Product | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { addItem, error: cartError, loading } = useCart();
+  const [adding, setAdding] = useState(false);
+  const [added, setAdded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getProduct(productId)
+      .then((p) => !cancelled && setProduct(p))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Failed to load'));
+    return () => {
+      cancelled = true;
+    };
+  }, [productId]);
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>{error}</Text>
+      </View>
+    );
+  }
+
+  if (!product) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  const onAdd = async () => {
+    setAdding(true);
+    setAdded(false);
+    await addItem(product.id, 1);
+    setAdding(false);
+    setAdded(true);
+  };
+
+  const outOfStock = product.stock === 0;
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.name}>{product.name}</Text>
+      <Text style={styles.category}>{product.category}</Text>
+      <Text style={styles.price}>{formatGBP(product.priceCents)}</Text>
+      <Text style={styles.description}>{product.description}</Text>
+      <Text style={outOfStock ? styles.oos : styles.stock}>
+        {outOfStock ? 'Out of stock' : `${product.stock} in stock`}
+      </Text>
+
+      <Pressable
+        onPress={onAdd}
+        disabled={outOfStock || adding || loading}
+        style={({ pressed }) => [
+          styles.btn,
+          (outOfStock || adding) && styles.btnDisabled,
+          pressed && !outOfStock && styles.btnPressed,
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="Add to cart"
+      >
+        <Text style={styles.btnText}>
+          {adding ? 'Adding…' : outOfStock ? 'Out of stock' : 'Add to cart'}
+        </Text>
+      </Pressable>
+
+      {cartError && <Text style={styles.error}>{cartError}</Text>}
+      {added && !cartError && (
+        <Pressable onPress={() => navigation.navigate('Cart')}>
+          <Text style={styles.viewCart}>Added — view cart</Text>
+        </Pressable>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 24, gap: 12 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  name: { fontSize: 24, fontWeight: '700' },
+  category: { color: '#6b7280', textTransform: 'uppercase', fontSize: 12, letterSpacing: 1 },
+  price: { fontSize: 22, fontWeight: '600' },
+  description: { fontSize: 15, lineHeight: 22, color: '#374151' },
+  stock: { color: '#16a34a' },
+  oos: { color: '#b91c1c', fontWeight: '600' },
+  btn: {
+    backgroundColor: '#111827',
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: 'center',
+    marginTop: 12,
+  },
+  btnPressed: { backgroundColor: '#374151' },
+  btnDisabled: { backgroundColor: '#9ca3af' },
+  btnText: { color: '#fff', fontWeight: '600', fontSize: 16 },
+  error: { color: '#b91c1c', textAlign: 'center' },
+  viewCart: { color: '#2563eb', textAlign: 'center', fontWeight: '600' },
+});

--- a/mobile/src/screens/ProductListScreen.tsx
+++ b/mobile/src/screens/ProductListScreen.tsx
@@ -1,0 +1,128 @@
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { api } from '../api';
+import { useCart } from '../CartContext';
+import { formatGBP } from '../format';
+import { RootStackParamList } from '../navigation';
+import { Product } from '../types';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ProductList'>;
+
+export function ProductListScreen({ navigation }: Props) {
+  const [products, setProducts] = useState<Product[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const { cart } = useCart();
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const list = await api.listProducts();
+      setProducts(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load products');
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: () => (
+        <Pressable
+          onPress={() => navigation.navigate('Cart')}
+          accessibilityRole="button"
+          accessibilityLabel="View cart"
+        >
+          <Text style={styles.cartLink}>Cart{cart ? ` (${cartCount(cart.lines)})` : ''}</Text>
+        </Pressable>
+      ),
+    });
+  }, [navigation, cart]);
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await load();
+    setRefreshing(false);
+  }, [load]);
+
+  if (!products && !error) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.error}>{error}</Text>
+        <Pressable onPress={load} style={styles.retry}>
+          <Text style={styles.retryText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <FlatList
+      data={products ?? []}
+      keyExtractor={(p) => p.id}
+      contentContainerStyle={styles.list}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      renderItem={({ item }) => (
+        <Pressable
+          onPress={() => navigation.navigate('ProductDetail', { productId: item.id })}
+          style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+          accessibilityRole="button"
+        >
+          <Text style={styles.name}>{item.name}</Text>
+          <View style={styles.metaRow}>
+            <Text style={styles.price}>{formatGBP(item.priceCents)}</Text>
+            <Text style={item.stock === 0 ? styles.oos : styles.stock}>
+              {item.stock === 0 ? 'Out of stock' : `${item.stock} in stock`}
+            </Text>
+          </View>
+        </Pressable>
+      )}
+    />
+  );
+}
+
+function cartCount(lines: { quantity: number }[]): number {
+  return lines.reduce((s, l) => s + l.quantity, 0);
+}
+
+const styles = StyleSheet.create({
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  list: { padding: 16, gap: 12 },
+  row: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  rowPressed: { backgroundColor: '#f3f4f6' },
+  name: { fontSize: 16, fontWeight: '600', marginBottom: 6 },
+  metaRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  price: { fontSize: 16 },
+  stock: { color: '#16a34a' },
+  oos: { color: '#b91c1c', fontWeight: '600' },
+  error: { color: '#b91c1c', textAlign: 'center', marginBottom: 12 },
+  retry: { padding: 12 },
+  retryText: { color: '#2563eb', fontWeight: '600' },
+  cartLink: { color: '#2563eb', fontWeight: '600', marginRight: 8 },
+});


### PR DESCRIPTION
## Summary
- ProductListScreen (FlatList, refresh, cart-link header showing item count)
- ProductDetailScreen (full details, add-to-cart with disabled state on out-of-stock)
- CartScreen (per-line +/− qty controls, remove, running subtotal, checkout)
- CheckoutScreen (order summary: lines, applied discounts, grand total)
- App.tsx wires the stack inside SafeAreaProvider + CartProvider

## Test plan
- [x] Types reference RootStackParamList for type-safe nav
- [x] Component tests next PR