### PR TITLE
feat(cart-expiry): countdown timer + auto-recreate + expiry banner

### DIFF
--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -137,6 +137,17 @@ The read-modify-write `stock - quantity` pattern is safe under Node's single-thr
 
 `touch(cart)` resets `lastActivityAt` on every successful add/update/remove, so an active shopper isn't penalised. `markCheckedOut` is the success path: stock stays decremented (the items were sold), cart transitions out of `active` so it can't be mutated.
 
+Every `Cart` returned to a caller carries an `expiresAt: number` (epoch ms, computed as `lastActivityAt + RESERVATION_TTL_MS`) so the client can drive a visible countdown without polling. The field is derived in a single `view()` helper so it can never drift from the BFF's own TTL constant.
+
+### Mobile cart-expiry UX
+
+- A `<CartTimer />` component is mounted in the header of `ProductList`, `ProductDetail`, and `Cart` (not Checkout). It renders `mm:ss` until `cart.expiresAt`, driven by a 1-second ticker in `CartProvider` that only runs while a cart exists.
+- Expiry is detected two ways:
+  - **Proactive** — the ticker observes `Date.now() >= cart.expiresAt`.
+  - **Reactive** — any mutation that rejects with `/is expired/i`.
+- On either path the provider clears the local `cart`, sets `expiredNotice`, and immediately auto-mints a new cart via the existing in-flight `createCart` ref so a proactive + reactive collision can't double-mint. **Previously-held line items are not restored** — the BFF has already released their reservations and the catalogue may have shifted, so re-adding is a deliberate user action.
+- `CartScreen` shows a dismissible yellow banner sourced from `expiredNotice`. `ProductDetailScreen` swaps its raw cart-error line for the same notice when an `addItem` fails on an expired cart, since the context has already auto-recreated.
+
 ### Stock-failure path
 
 A naïve design would check stock at checkout. Because we reserve at add-to-cart time, **the only place a stock failure can surface is `POST /carts/:id/items`** (or `PATCH` raising the qty). Once a line is in the cart, the inventory is provably held. Checkout failures reduce to: unknown cart, empty cart, expired/already-checked-out cart. The mobile UI shows the BFF's error message verbatim ("Insufficient stock for Sourdough Loaf: requested 5, available 12") on the Detail / Cart screens.

--- a/bff/src/carts/cart.entity.ts
+++ b/bff/src/carts/cart.entity.ts
@@ -11,4 +11,5 @@ export interface Cart {
   lines: CartLine[];
   createdAt: number;
   lastActivityAt: number;
+  expiresAt: number;
 }

--- a/bff/src/carts/carts.service.spec.ts
+++ b/bff/src/carts/carts.service.spec.ts
@@ -72,4 +72,28 @@ describe('CartsService', () => {
   it('throws NotFound for unknown cart', () => {
     expect(() => carts.get('nope')).toThrow(NotFoundException);
   });
+
+  describe('expiresAt projection', () => {
+    it('create() sets expiresAt = lastActivityAt + RESERVATION_TTL_MS', () => {
+      const cart = carts.create();
+      expect(cart.expiresAt).toBe(cart.lastActivityAt + RESERVATION_TTL_MS);
+    });
+
+    it('addItem advances expiresAt because touch() updates lastActivityAt', async () => {
+      const cart = carts.create();
+      const initialExpiresAt = cart.expiresAt;
+      // Wait at least 2ms to guarantee Date.now() ticks forward
+      await new Promise((r) => setTimeout(r, 5));
+      const updated = carts.addItem(cart.id, 'p-coffee-beans', 1);
+      expect(updated.expiresAt).toBeGreaterThan(initialExpiresAt);
+      expect(updated.expiresAt).toBe(updated.lastActivityAt + RESERVATION_TTL_MS);
+    });
+
+    it('get() of an active cart includes a populated expiresAt', () => {
+      const cart = carts.create();
+      const fetched = carts.get(cart.id);
+      expect(fetched.expiresAt).toBe(fetched.lastActivityAt + RESERVATION_TTL_MS);
+      expect(fetched.expiresAt).toBeGreaterThan(0);
+    });
+  });
 });

--- a/bff/src/carts/carts.service.ts
+++ b/bff/src/carts/carts.service.ts
@@ -36,16 +36,17 @@ export class CartsService implements OnModuleDestroy {
       lines: [],
       createdAt: now,
       lastActivityAt: now,
+      expiresAt: now + RESERVATION_TTL_MS,
     };
     this.carts.set(cart.id, cart);
-    return { ...cart, lines: [...cart.lines] };
+    return this.view(cart);
   }
 
   get(id: string): Cart {
     this.sweepExpired();
     const cart = this.carts.get(id);
     if (!cart) throw new NotFoundException(`Cart ${id} not found`);
-    return { ...cart, lines: cart.lines.map((l) => ({ ...l })) };
+    return this.view(cart);
   }
 
   addItem(cartId: string, productId: string, quantity: number): Cart {
@@ -134,5 +135,14 @@ export class CartsService implements OnModuleDestroy {
 
   private touch(cart: Cart): void {
     cart.lastActivityAt = Date.now();
+    cart.expiresAt = cart.lastActivityAt + RESERVATION_TTL_MS;
+  }
+
+  private view(cart: Cart): Cart {
+    return {
+      ...cart,
+      lines: cart.lines.map((l) => ({ ...l })),
+      expiresAt: cart.lastActivityAt + RESERVATION_TTL_MS,
+    };
   }
 }

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -4,6 +4,7 @@ import { StatusBar } from 'expo-status-bar';
 import React from 'react';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { CartProvider } from './src/CartContext';
+import { CartTimer } from './src/components/CartTimer';
 import { RootStackParamList } from './src/navigation';
 import { CartScreen } from './src/screens/CartScreen';
 import { CheckoutScreen } from './src/screens/CheckoutScreen';
@@ -26,12 +27,12 @@ export default function App() {
             <Stack.Screen
               name="ProductDetail"
               component={ProductDetailScreen}
-              options={{ title: 'Product' }}
+              options={{ title: 'Product', headerRight: () => <CartTimer /> }}
             />
             <Stack.Screen
               name="Cart"
               component={CartScreen}
-              options={{ title: 'Your cart' }}
+              options={{ title: 'Your cart', headerRight: () => <CartTimer /> }}
             />
             <Stack.Screen
               name="Checkout"

--- a/mobile/src/CartContext.test.tsx
+++ b/mobile/src/CartContext.test.tsx
@@ -67,4 +67,143 @@ describe('CartContext', () => {
     });
     expect(result.current.error).toMatch(/Insufficient stock/);
   });
+
+  describe('cart expiry UX', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('proactive expiry: ticker observes Date.now() >= expiresAt', async () => {
+      jest.useFakeTimers();
+      const { result } = renderHook(() => useCart(), { wrapper });
+
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      expect(api.createCart).toHaveBeenCalledTimes(1);
+      const firstCartId = result.current.cart?.id;
+      expect(firstCartId).toBe('cart-1');
+
+      // Advance just past the 2-minute TTL — the ticker should fire expiry.
+      await act(async () => {
+        jest.advanceTimersByTime(121_000);
+      });
+      // Flush the createCart() promise queued by handleExpiry.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(result.current.expiredNotice).toMatch(/expired/i);
+      expect(api.createCart).toHaveBeenCalledTimes(2);
+      // After auto-recreate the new cart should be set.
+      expect(result.current.cart?.id).toBe('cart-2');
+    });
+
+    it('reactive expiry: a mutation rejecting with /is expired/ triggers the same effects', async () => {
+      const { result } = renderHook(() => useCart(), { wrapper });
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      expect(api.createCart).toHaveBeenCalledTimes(1);
+
+      api.addItem.mockRejectedValueOnce(new Error('Cart cart-1 is expired'));
+
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      // Flush createCart() promise from handleExpiry.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.expiredNotice).toMatch(/expired/i);
+      expect(result.current.error).toBeNull();
+      expect(api.createCart).toHaveBeenCalledTimes(2);
+      expect(result.current.cart?.id).toBe('cart-2');
+    });
+
+    it('proactive + reactive firing together still mints exactly one new cart', async () => {
+      jest.useFakeTimers();
+      const { result } = renderHook(() => useCart(), { wrapper });
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      expect(api.createCart).toHaveBeenCalledTimes(1);
+
+      // Suspend the next createCart so the in-flight ref stays set while both
+      // expiry paths fire — this is the actual concurrency the dedupe protects.
+      let releaseCreate!: (cart: import('../src/types').Cart | any) => void;
+      const pending = new Promise((resolve) => {
+        releaseCreate = resolve;
+      });
+      api.createCart.mockImplementationOnce(() => pending as any);
+
+      // Reactive path: addItem rejects with expired -> handleExpiry fires.
+      api.addItem.mockRejectedValueOnce(new Error('Cart cart-1 is expired'));
+
+      // Fire proactive (ticker) and reactive (addItem) within the same act —
+      // the suspended createCart guarantees they overlap.
+      await act(async () => {
+        jest.advanceTimersByTime(121_000);
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+
+      // While the in-flight createCart is still pending, the second handleExpiry
+      // call must NOT have started a third createCart.
+      expect(api.createCart).toHaveBeenCalledTimes(2);
+
+      // Now release: still only 2 total.
+      await act(async () => {
+        releaseCreate({
+          id: 'cart-2',
+          status: 'active',
+          lines: [],
+          createdAt: Date.now(),
+          lastActivityAt: Date.now(),
+          expiresAt: Date.now() + 120_000,
+        });
+        await Promise.resolve();
+      });
+      expect(api.createCart).toHaveBeenCalledTimes(2);
+    });
+
+    it('secondsRemaining decreases by 1 each fake-timer tick', async () => {
+      jest.useFakeTimers();
+      const { result } = renderHook(() => useCart(), { wrapper });
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      const start = result.current.secondsRemaining;
+      expect(start).toBeGreaterThan(0);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1_000);
+      });
+      expect(result.current.secondsRemaining).toBe(start - 1);
+
+      await act(async () => {
+        jest.advanceTimersByTime(1_000);
+      });
+      expect(result.current.secondsRemaining).toBe(start - 2);
+    });
+
+    it('dismissExpiredNotice() clears expiredNotice', async () => {
+      const { result } = renderHook(() => useCart(), { wrapper });
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      api.addItem.mockRejectedValueOnce(new Error('Cart cart-1 is expired'));
+      await act(async () => {
+        await result.current.addItem('p-coffee-beans', 1);
+      });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(result.current.expiredNotice).toMatch(/expired/i);
+
+      act(() => result.current.dismissExpiredNotice());
+      expect(result.current.expiredNotice).toBeNull();
+    });
+  });
 });

--- a/mobile/src/CartContext.tsx
+++ b/mobile/src/CartContext.tsx
@@ -3,6 +3,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -10,16 +11,23 @@ import React, {
 import { api } from './api';
 import { Cart } from './types';
 
+const EXPIRED_NOTICE =
+  'Your cart expired after 2 minutes of inactivity — we started a fresh one.';
+
 interface CartContextValue {
   cart: Cart | null;
   loading: boolean;
   error: string | null;
+  expiresAt: number | null;
+  secondsRemaining: number;
+  expiredNotice: string | null;
   createCart: () => Promise<void>;
   refresh: () => Promise<void>;
   addItem: (productId: string, quantity?: number) => Promise<void>;
   updateItem: (productId: string, quantity: number) => Promise<void>;
   removeItem: (productId: string) => Promise<void>;
   clear: () => void;
+  dismissExpiredNotice: () => void;
 }
 
 const CartContext = createContext<CartContextValue | null>(null);
@@ -33,10 +41,47 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const [cart, setCart] = useState<Cart | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [secondsRemaining, setSecondsRemaining] = useState(0);
+  const [expiredNotice, setExpiredNotice] = useState<string | null>(null);
   // Holds the in-flight createCart() promise so two rapid addItem taps don't mint two carts.
   const cartCreation = useRef<Promise<Cart> | null>(null);
   const cartRef = useRef<Cart | null>(null);
   cartRef.current = cart;
+
+  const handleExpiry = useCallback(() => {
+    setCart(null);
+    setError(null);
+    setExpiredNotice(EXPIRED_NOTICE);
+    // Reuse the in-flight ref so we never double-mint, even if proactive + reactive fire together.
+    if (!cartCreation.current) {
+      cartCreation.current = api.createCart().then((c) => {
+        setCart(c);
+        return c;
+      });
+      cartCreation.current.finally(() => {
+        cartCreation.current = null;
+      });
+    }
+  }, []);
+
+  // 1-second ticker — only runs while a cart exists. Drives the visible timer and
+  // proactively triggers expiry when the BFF's TTL has elapsed.
+  useEffect(() => {
+    if (!cart) {
+      setSecondsRemaining(0);
+      return;
+    }
+    const tick = () => {
+      const remaining = Math.max(0, Math.ceil((cart.expiresAt - Date.now()) / 1000));
+      setSecondsRemaining(remaining);
+      if (Date.now() >= cart.expiresAt) {
+        handleExpiry();
+      }
+    };
+    tick();
+    const handle = setInterval(tick, 1000);
+    return () => clearInterval(handle);
+  }, [cart, handleExpiry]);
 
   const wrap = useCallback(async <T,>(fn: () => Promise<T>): Promise<T | undefined> => {
     setLoading(true);
@@ -44,12 +89,17 @@ export function CartProvider({ children }: { children: ReactNode }) {
     try {
       return await fn();
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Something went wrong');
+      const message = e instanceof Error ? e.message : 'Something went wrong';
+      if (/is expired/i.test(message)) {
+        handleExpiry();
+      } else {
+        setError(message);
+      }
       return undefined;
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [handleExpiry]);
 
   const createCart = useCallback(async () => {
     await wrap(async () => {
@@ -118,11 +168,42 @@ export function CartProvider({ children }: { children: ReactNode }) {
     setError(null);
   }, []);
 
+  const dismissExpiredNotice = useCallback(() => {
+    setExpiredNotice(null);
+  }, []);
+
   // Lazy: don't create a cart until the user actually adds an item. Reservations matter.
 
   const value = useMemo<CartContextValue>(
-    () => ({ cart, loading, error, createCart, refresh, addItem, updateItem, removeItem, clear }),
-    [cart, loading, error, createCart, refresh, addItem, updateItem, removeItem, clear],
+    () => ({
+      cart,
+      loading,
+      error,
+      expiresAt: cart?.expiresAt ?? null,
+      secondsRemaining,
+      expiredNotice,
+      createCart,
+      refresh,
+      addItem,
+      updateItem,
+      removeItem,
+      clear,
+      dismissExpiredNotice,
+    }),
+    [
+      cart,
+      loading,
+      error,
+      secondsRemaining,
+      expiredNotice,
+      createCart,
+      refresh,
+      addItem,
+      updateItem,
+      removeItem,
+      clear,
+      dismissExpiredNotice,
+    ],
   );
 
   return <CartContext.Provider value={value}>{children}</CartContext.Provider>;

--- a/mobile/src/__mocks__/api.ts
+++ b/mobile/src/__mocks__/api.ts
@@ -29,6 +29,7 @@ function makeCart(id: string): Cart {
     lines: [],
     createdAt: Date.now(),
     lastActivityAt: Date.now(),
+    expiresAt: Date.now() + 2 * 60 * 1000,
   };
 }
 

--- a/mobile/src/components/CartTimer.test.tsx
+++ b/mobile/src/components/CartTimer.test.tsx
@@ -1,0 +1,75 @@
+import { render } from '@testing-library/react-native';
+import React from 'react';
+import { Cart } from '../types';
+import { CartTimer } from './CartTimer';
+
+// We mock useCart directly so the component can be exercised in isolation
+// without standing up CartProvider + the 1-second ticker.
+jest.mock('../CartContext', () => ({
+  useCart: jest.fn(),
+}));
+
+import { useCart } from '../CartContext';
+
+const mockUseCart = useCart as jest.MockedFunction<typeof useCart>;
+
+function makeCart(overrides: Partial<Cart> = {}): Cart {
+  const now = Date.now();
+  return {
+    id: 'cart-1',
+    status: 'active',
+    lines: [],
+    createdAt: now,
+    lastActivityAt: now,
+    expiresAt: now + 120_000,
+    ...overrides,
+  };
+}
+
+function setCartContext(cart: Cart | null, secondsRemaining: number) {
+  mockUseCart.mockReturnValue({
+    cart,
+    loading: false,
+    error: null,
+    expiresAt: cart?.expiresAt ?? null,
+    secondsRemaining,
+    expiredNotice: null,
+    createCart: jest.fn(),
+    refresh: jest.fn(),
+    addItem: jest.fn(),
+    updateItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+    dismissExpiredNotice: jest.fn(),
+  } as ReturnType<typeof useCart>);
+}
+
+describe('CartTimer', () => {
+  beforeEach(() => {
+    mockUseCart.mockReset();
+  });
+
+  it('returns null when no cart', () => {
+    setCartContext(null, 0);
+    const { toJSON } = render(<CartTimer />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders 2:00 when 120 seconds remain', () => {
+    setCartContext(makeCart(), 120);
+    const { getByText } = render(<CartTimer />);
+    expect(getByText('2:00')).toBeTruthy();
+  });
+
+  it('pads single-digit seconds (renders 0:09 when 9)', () => {
+    setCartContext(makeCart(), 9);
+    const { getByText } = render(<CartTimer />);
+    expect(getByText('0:09')).toBeTruthy();
+  });
+
+  it('exposes an accessibilityLabel describing remaining time', () => {
+    setCartContext(makeCart(), 75);
+    const { getByLabelText } = render(<CartTimer />);
+    expect(getByLabelText('Cart expires in 1 minutes 15 seconds')).toBeTruthy();
+  });
+});

--- a/mobile/src/components/CartTimer.tsx
+++ b/mobile/src/components/CartTimer.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useCart } from '../CartContext';
+
+export function CartTimer() {
+  const { cart, secondsRemaining } = useCart();
+  if (!cart) return null;
+
+  const minutes = Math.floor(secondsRemaining / 60);
+  const seconds = secondsRemaining % 60;
+  const display = `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  const lowTime = secondsRemaining <= 30;
+
+  return (
+    <View style={styles.container}>
+      <Text
+        style={[styles.text, lowTime && styles.textLow]}
+        accessibilityLabel={`Cart expires in ${minutes} minutes ${seconds} seconds`}
+      >
+        {display}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    marginRight: 8,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '600',
+    fontVariant: ['tabular-nums'],
+    color: '#374151',
+  },
+  textLow: {
+    color: '#b91c1c',
+  },
+});

--- a/mobile/src/screens/CartScreen.test.tsx
+++ b/mobile/src/screens/CartScreen.test.tsx
@@ -1,0 +1,71 @@
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { CartScreen } from './CartScreen';
+import { RootStackParamList } from '../navigation';
+
+// Mock useCart so we can drive expiredNotice + dismissExpiredNotice directly,
+// without standing up the real provider/ticker.
+jest.mock('../CartContext', () => ({
+  useCart: jest.fn(),
+}));
+jest.mock('../api', () => require('../__mocks__/api'));
+
+import { useCart } from '../CartContext';
+
+const mockUseCart = useCart as jest.MockedFunction<typeof useCart>;
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+const Harness = () => (
+  <NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Cart" component={CartScreen} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+function setCart(overrides: Partial<ReturnType<typeof useCart>> = {}) {
+  const dismiss = jest.fn();
+  mockUseCart.mockReturnValue({
+    cart: null,
+    loading: false,
+    error: null,
+    expiresAt: null,
+    secondsRemaining: 0,
+    expiredNotice: null,
+    createCart: jest.fn(),
+    refresh: jest.fn(),
+    addItem: jest.fn(),
+    updateItem: jest.fn(),
+    removeItem: jest.fn(),
+    clear: jest.fn(),
+    dismissExpiredNotice: dismiss,
+    ...overrides,
+  } as ReturnType<typeof useCart>);
+  return { dismiss };
+}
+
+describe('CartScreen expiry banner', () => {
+  beforeEach(() => {
+    mockUseCart.mockReset();
+  });
+
+  const NOTICE = 'Your cart expired after 2 minutes of inactivity — we started a fresh one.';
+
+  it('renders no banner when expiredNotice is null', async () => {
+    setCart({ expiredNotice: null });
+    const { queryByText } = render(<Harness />);
+    await waitFor(() => expect(queryByText(NOTICE)).toBeNull());
+  });
+
+  it('shows the expiry banner when expiredNotice is set, and dismisses on tap', async () => {
+    const { dismiss } = setCart({ expiredNotice: NOTICE });
+    const { findByText, getByLabelText } = render(<Harness />);
+    expect(await findByText(NOTICE)).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Dismiss'));
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/src/screens/CartScreen.tsx
+++ b/mobile/src/screens/CartScreen.tsx
@@ -22,7 +22,8 @@ interface EnrichedLine {
 }
 
 export function CartScreen({ navigation }: Props) {
-  const { cart, error, loading, updateItem, removeItem, clear } = useCart();
+  const { cart, error, loading, updateItem, removeItem, clear, expiredNotice, dismissExpiredNotice } =
+    useCart();
   const [lines, setLines] = useState<EnrichedLine[] | null>(null);
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [checkingOut, setCheckingOut] = useState(false);
@@ -65,13 +66,29 @@ export function CartScreen({ navigation }: Props) {
     }
   };
 
+  const banner = expiredNotice ? (
+    <View style={styles.banner} accessibilityRole="alert">
+      <Text style={styles.bannerText}>{expiredNotice}</Text>
+      <Pressable
+        onPress={dismissExpiredNotice}
+        accessibilityRole="button"
+        accessibilityLabel="Dismiss"
+      >
+        <Text style={styles.bannerDismiss}>Dismiss</Text>
+      </Pressable>
+    </View>
+  ) : null;
+
   if (!cart || (lines && lines.length === 0)) {
     return (
-      <View style={styles.empty}>
-        <Text style={styles.emptyText}>Your cart is empty.</Text>
-        <Pressable onPress={() => navigation.navigate('ProductList')}>
-          <Text style={styles.link}>Browse products</Text>
-        </Pressable>
+      <View style={styles.container}>
+        {banner}
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>Your cart is empty.</Text>
+          <Pressable onPress={() => navigation.navigate('ProductList')}>
+            <Text style={styles.link}>Browse products</Text>
+          </Pressable>
+        </View>
       </View>
     );
   }
@@ -102,6 +119,7 @@ export function CartScreen({ navigation }: Props) {
 
   return (
     <View style={styles.container}>
+      {banner}
       <FlatList
         data={lines ?? []}
         keyExtractor={(l) => l.product.id}
@@ -225,4 +243,15 @@ const styles = StyleSheet.create({
   pressed: { backgroundColor: '#374151' },
   disabled: { backgroundColor: '#9ca3af' },
   checkoutText: { color: '#fff', fontWeight: '600', fontSize: 16 },
+  banner: {
+    backgroundColor: '#fef3c7',
+    borderBottomWidth: 1,
+    borderBottomColor: '#fcd34d',
+    padding: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  bannerText: { flex: 1, color: '#78350f', fontSize: 14 },
+  bannerDismiss: { color: '#78350f', fontWeight: '700' },
 });

--- a/mobile/src/screens/ProductDetailScreen.tsx
+++ b/mobile/src/screens/ProductDetailScreen.tsx
@@ -20,7 +20,7 @@ export function ProductDetailScreen({ route, navigation }: Props) {
   const { productId } = route.params;
   const [product, setProduct] = useState<Product | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { addItem, error: cartError, loading } = useCart();
+  const { addItem, error: cartError, loading, expiredNotice } = useCart();
   const [adding, setAdding] = useState(false);
   const [added, setAdded] = useState(false);
 
@@ -87,8 +87,12 @@ export function ProductDetailScreen({ route, navigation }: Props) {
         </Text>
       </Pressable>
 
-      {cartError && <Text style={styles.error}>{cartError}</Text>}
-      {added && !cartError && (
+      {expiredNotice ? (
+        <Text style={styles.notice}>Cart expired — we started a fresh one. Try adding again.</Text>
+      ) : (
+        cartError && <Text style={styles.error}>{cartError}</Text>
+      )}
+      {added && !cartError && !expiredNotice && (
         <Pressable onPress={() => navigation.navigate('Cart')}>
           <Text style={styles.viewCart}>Added — view cart</Text>
         </Pressable>
@@ -118,4 +122,5 @@ const styles = StyleSheet.create({
   btnText: { color: '#fff', fontWeight: '600', fontSize: 16 },
   error: { color: '#b91c1c', textAlign: 'center' },
   viewCart: { color: '#2563eb', textAlign: 'center', fontWeight: '600' },
+  notice: { color: '#78350f', textAlign: 'center' },
 });

--- a/mobile/src/screens/ProductListScreen.tsx
+++ b/mobile/src/screens/ProductListScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { api } from '../api';
 import { useCart } from '../CartContext';
+import { CartTimer } from '../components/CartTimer';
 import { formatGBP } from '../format';
 import { RootStackParamList } from '../navigation';
 import { Product } from '../types';
@@ -43,13 +44,16 @@ export function ProductListScreen({ navigation }: Props) {
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <Pressable
-          onPress={() => navigation.navigate('Cart')}
-          accessibilityRole="button"
-          accessibilityLabel="View cart"
-        >
-          <Text style={styles.cartLink}>Cart{cart ? ` (${cartCount(cart.lines)})` : ''}</Text>
-        </Pressable>
+        <View style={styles.headerRight}>
+          <CartTimer />
+          <Pressable
+            onPress={() => navigation.navigate('Cart')}
+            accessibilityRole="button"
+            accessibilityLabel="View cart"
+          >
+            <Text style={styles.cartLink}>Cart{cart ? ` (${cartCount(cart.lines)})` : ''}</Text>
+          </Pressable>
+        </View>
       ),
     });
   }, [navigation, cart]);
@@ -128,4 +132,5 @@ const styles = StyleSheet.create({
   retry: { padding: 12 },
   retryText: { color: '#2563eb', fontWeight: '600' },
   cartLink: { color: '#2563eb', fontWeight: '600', marginRight: 8 },
+  headerRight: { flexDirection: 'row', alignItems: 'center' },
 });

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -21,6 +21,7 @@ export interface Cart {
   lines: CartLine[];
   createdAt: number;
   lastActivityAt: number;
+  expiresAt: number;
 }
 
 export interface AppliedDiscount {


### PR DESCRIPTION
## Summary
- BFF returns `expiresAt = lastActivityAt + RESERVATION_TTL_MS` on every cart response so the client has an authoritative deadline.
- Mobile shows a `mm:ss` countdown (`CartTimer`) in the screen header during a cart session, turning red under 30s.
- When the cart expires (proactive ticker or reactive `/is expired/i` rejection), the client clears the cart, surfaces a dismissible banner, and auto-creates a fresh cart (deduped via the existing in-flight `createCart` ref). Line items are not restored — documented in `SOLUTION.md`.

## Test plan
- [x] `npm run test:bff` — 40 unit + 5 e2e green
- [x] `npm run test:mobile` — 26 across 7 suites green (new: BFF expiresAt projection, CartContext expiry behaviour, CartTimer rendering, CartScreen banner)
- [ ] Manual: start cart, watch timer count down, leave idle 2m, confirm banner + fresh cart on next add

🤖 Generated with [Claude Code](https://claude.com/claude-code)