### PR TITLE
feat(mobile): live stock decrement on detail Add to cart

### DIFF
--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -209,6 +209,8 @@ Per-screen async state (catalogue list, product detail) lives in the screen with
 - `format.ts` for currency, `api.ts` for the typed fetch client.
 - Vanilla `StyleSheet` — no UI library.
 - Interactive elements have `accessibilityRole`/`accessibilityLabel`.
+- `ProductListScreen` refetches via `useFocusEffect` so stock reflects the latest state after returning from checkout.
+- `ProductDetailScreen` decrements its displayed stock optimistically the moment **Add to cart** is pressed, then refetches the product to reconcile with the BFF (which reserves stock server-side on add). The user sees an instant response; any divergence is corrected by the refetch.
 
 ### UI / Branding
 

--- a/mobile/src/screens/ProductDetailScreen.test.tsx
+++ b/mobile/src/screens/ProductDetailScreen.test.tsx
@@ -39,6 +39,29 @@ describe('ProductDetailScreen', () => {
     expect(api.addItem).toHaveBeenCalledWith('cart-1', 'p-coffee-beans', 1);
   });
 
+  it('decreases displayed stock when Add to cart is pressed', async () => {
+    const baseProduct = {
+      id: 'p-coffee-beans',
+      name: 'Coffee Beans',
+      description: 'Single-origin coffee.',
+      category: 'pantry',
+      priceCents: 1299,
+      stock: 10,
+    };
+    api.getProduct
+      .mockResolvedValueOnce(baseProduct)
+      .mockResolvedValueOnce({ ...baseProduct, stock: 9 });
+
+    const { findByText, getByLabelText } = render(<Harness productId="p-coffee-beans" />);
+    expect(await findByText('10 in stock')).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Add to cart'));
+
+    await waitFor(() => expect(api.addItem).toHaveBeenCalledTimes(1));
+    expect(await findByText('9 in stock')).toBeTruthy();
+    expect(api.getProduct).toHaveBeenCalledTimes(2);
+  });
+
   it('disables Add to cart when product is out of stock', async () => {
     const { findByText, getByLabelText } = render(<Harness productId="p-oat-milk" />);
     expect(await findByText('Oat Milk')).toBeTruthy();

--- a/mobile/src/screens/ProductDetailScreen.test.tsx
+++ b/mobile/src/screens/ProductDetailScreen.test.tsx
@@ -62,6 +62,32 @@ describe('ProductDetailScreen', () => {
     expect(api.getProduct).toHaveBeenCalledTimes(2);
   });
 
+  it('reconciles displayed stock when Add to cart fails', async () => {
+    const baseProduct = {
+      id: 'p-coffee-beans',
+      name: 'Coffee Beans',
+      description: 'Single-origin coffee.',
+      category: 'pantry',
+      priceCents: 1299,
+      stock: 10,
+    };
+    api.getProduct
+      .mockResolvedValueOnce(baseProduct)
+      .mockResolvedValueOnce({ ...baseProduct, stock: 10 });
+    api.addItem.mockRejectedValueOnce(new Error('Insufficient stock'));
+
+    const { findByText, getByLabelText } = render(<Harness productId="p-coffee-beans" />);
+    expect(await findByText('10 in stock')).toBeTruthy();
+
+    fireEvent.press(getByLabelText('Add to cart'));
+
+    // Optimistic decrement flips to 9, then refetch reconciles back to 10.
+    await waitFor(() => expect(api.getProduct).toHaveBeenCalledTimes(2));
+    expect(await findByText('10 in stock')).toBeTruthy();
+    // Button is no longer stuck in the "Adding…" state.
+    expect(await findByText('Add to cart')).toBeTruthy();
+  });
+
   it('disables Add to cart when product is out of stock', async () => {
     const { findByText, getByLabelText } = render(<Harness productId="p-oat-milk" />);
     expect(await findByText('Oat Milk')).toBeTruthy();

--- a/mobile/src/screens/ProductDetailScreen.tsx
+++ b/mobile/src/screens/ProductDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -25,16 +25,18 @@ export function ProductDetailScreen({ route, navigation }: Props) {
   const [adding, setAdding] = useState(false);
   const [added, setAdded] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .getProduct(productId)
-      .then((p) => !cancelled && setProduct(p))
-      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Failed to load'));
-    return () => {
-      cancelled = true;
-    };
+  const loadProduct = useCallback(async () => {
+    try {
+      const p = await api.getProduct(productId);
+      setProduct(p);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load');
+    }
   }, [productId]);
+
+  useEffect(() => {
+    void loadProduct();
+  }, [loadProduct]);
 
   if (error) {
     return (
@@ -55,9 +57,11 @@ export function ProductDetailScreen({ route, navigation }: Props) {
   const onAdd = async () => {
     setAdding(true);
     setAdded(false);
+    setProduct((p) => (p ? { ...p, stock: Math.max(0, p.stock - 1) } : p));
     await addItem(product.id, 1);
     setAdding(false);
     setAdded(true);
+    void loadProduct();
   };
 
   const outOfStock = product.stock === 0;

--- a/mobile/src/screens/ProductDetailScreen.tsx
+++ b/mobile/src/screens/ProductDetailScreen.tsx
@@ -35,8 +35,15 @@ export function ProductDetailScreen({ route, navigation }: Props) {
   }, [productId]);
 
   useEffect(() => {
-    void loadProduct();
-  }, [loadProduct]);
+    let cancelled = false;
+    api
+      .getProduct(productId)
+      .then((p) => !cancelled && setProduct(p))
+      .catch((e) => !cancelled && setError(e instanceof Error ? e.message : 'Failed to load'));
+    return () => {
+      cancelled = true;
+    };
+  }, [productId]);
 
   if (error) {
     return (
@@ -58,10 +65,13 @@ export function ProductDetailScreen({ route, navigation }: Props) {
     setAdding(true);
     setAdded(false);
     setProduct((p) => (p ? { ...p, stock: Math.max(0, p.stock - 1) } : p));
-    await addItem(product.id, 1);
-    setAdding(false);
-    setAdded(true);
-    void loadProduct();
+    try {
+      await addItem(product.id, 1);
+      setAdded(true);
+    } finally {
+      setAdding(false);
+      void loadProduct();
+    }
   };
 
   const outOfStock = product.stock === 0;


### PR DESCRIPTION
## Summary
- `ProductDetailScreen` now decrements its displayed stock optimistically the instant **Add to cart** is tapped, then refetches the product to reconcile with the BFF (which reserves stock server-side on add).
- Result: instant visual feedback, with the server remaining the source of truth — any divergence (e.g. concurrent reservation) is corrected by the refetch.
- Pure UX/data-flow change; no API surface changes, no new dependencies.

## Test plan
- [x] New spec: "decreases displayed stock when Add to cart is pressed" asserts the screen flips from "10 in stock" to "9 in stock" after a single tap, and that `getProduct` is called twice (initial + reconcile).
- [x] Full mobile suite: 28/28 passing
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)