### PR TITLE
chore(bff): bump class-validator + @types/supertest

### DIFF
--- a/bff/package.json
+++ b/bff/package.json
@@ -21,7 +21,7 @@
     "@nestjs/core": "^10.4.0",
     "@nestjs/platform-express": "^10.4.0",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.1",
+    "class-validator": "^0.15.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "uuid": "^10.0.0"
@@ -33,19 +33,19 @@
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
-    "@types/supertest": "^6.0.2",
+    "@types/supertest": "^7.2.0",
     "@types/uuid": "^10.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.0",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.5.4",
-    "eslint": "^8.57.0",
-    "eslint-config-prettier": "^9.1.0",
-    "@typescript-eslint/eslint-plugin": "^7.18.0",
-    "@typescript-eslint/parser": "^7.18.0"
+    "typescript": "^5.5.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/core": "^10.4.0",
         "@nestjs/platform-express": "^10.4.0",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.1",
+        "class-validator": "^0.15.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "uuid": "^10.0.0"
@@ -34,7 +34,7 @@
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.0",
-        "@types/supertest": "^6.0.2",
+        "@types/supertest": "^7.2.0",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
@@ -6711,9 +6711,9 @@
       }
     },
     "node_modules/@types/supertest": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
-      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8787,9 +8787,9 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
-      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",


### PR DESCRIPTION
## Summary
The smallest set of safe in-range major bumps from the dependency audit. Both have low blast radius and no breaking-change exposure for our usage.

- `class-validator` ^0.14 → ^0.15 — only consumed for DTO decorators in `bff/src`; 0.15 doesn't change the decorator API we use.
- `@types/supertest` ^6 → ^7 — dev-only types; e2e suite still types and runs.

Larger framework upgrades (Nest 11, Expo 55, TypeScript 6) are tracked in #18, #19, #20 — each needs its own focused PR with manual verification rather than bundling here.

## Test plan
- [x] `npm run lint` from root: clean
- [x] `npm test` from root: BFF 40 unit + 5 e2e green; mobile 29/29 green
- [x] `npx tsc --noEmit` (bff): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)