### PR TITLE
docs: refresh dependency references after Nest 11, TS 6, audit-fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See [`SOLUTION.md`](./SOLUTION.md) for design, API surface, catalogues, and assu
 
 ## Prerequisites
 
-- Node 18+ (tested on 20)
+- Node 20+ (required by NestJS 11)
 - npm 10+
 - For mobile: Expo Go on a phone, or an iOS Simulator / Android Emulator
 

--- a/SOLUTION.md
+++ b/SOLUTION.md
@@ -13,7 +13,7 @@ The repo is an npm workspaces monorepo so a single `npm install` at the root set
 
 ### Prerequisites
 
-- Node 18+ (tested on 20)
+- Node 20+ (required by NestJS 11)
 - npm 10+
 - For mobile: Expo Go on a phone, or an iOS Simulator / Android Emulator
 
@@ -260,6 +260,13 @@ Scripts:
 | `npm run format:check` | Prettier-check (used in CI / pre-merge) |
 
 Each workspace also has its own `lint` / `lint:fix` script for targeted runs.
+
+### Dependencies & security
+
+- **BFF** runs on **NestJS 11** (Node ≥ 20, Express 5, RxJS 7.8).
+- **Mobile** runs on **Expo SDK 51** / RN 0.74.5. The jump to Expo 55 + RN 0.85 was attempted and deferred — Expo 55 ships paired with RN 0.83, RN 0.85 needs Expo SDK 56, and `jest-expo@55`'s winter runtime requires a non-trivial test-setup rewrite. Tracked in issue #19.
+- **TypeScript 6** across both workspaces. The `bff/` ESLint stack stays on ESLint 8 + typescript-eslint 7 (whose `<6.1.0` peer range admits TS 6).
+- **`npm audit` is clean of high and critical findings.** A small set of root-level `overrides` in the top `package.json` pins vulnerable transitive leaves (`@xmldom/xmldom`, `send`, `tar`, `glob`) that no upstream upgrade currently reaches. Remaining moderates are tracked but not blocking.
 
 ---
 


### PR DESCRIPTION
## Summary
- Bumps the Node prerequisite from \`18+\` to \`20+\` in both README and SOLUTION (NestJS 11 requires Node ≥ 20).
- Adds a short **Dependencies & security** subsection to SOLUTION covering: NestJS 11, TypeScript 6 (with the typescript-eslint 7 peer-range note), why mobile stays on Expo SDK 51 for now (links #19), and the root-level npm \`overrides\` that keep \`npm audit\` clean of high / critical findings.

## Why
Follow-up to PRs #22 (Nest 11), #23 (TS 6), and #24 (audit overrides). The docs still claimed Node 18+ and gave no context for why the root \`package.json\` carries an \`overrides\` block.

## Test plan
- [x] No code touched — docs only
- [x] Read both files top-to-bottom; no other stale version references found